### PR TITLE
cmr-6818 - Adding a build and install action so that the library can be installed via pip3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,13 @@ jobs:
       - name: Run Unit Tests
         run: python3 -m unittest discover
         working-directory: ./CMR/python
+      - name: Lint
+        run: ./runme.sh -l
+        working-directory: ./CMR/python
+      - name: Package
+        run: python3 setup.py sdist bdist_wheel
+        working-directory: ./CMR/python
+      - uses: actions/upload-artifact@v2
+        with:
+          name: wheel
+          path: CMR/python/dist/eo_metadata_tools_cmr-*-py3-none-any.whl

--- a/CMR/python/LICENSE
+++ b/CMR/python/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 United States Government as represented by the Administrator of the National Aeronautics and Space Administration. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/CMR/python/README.md
+++ b/CMR/python/README.md
@@ -13,9 +13,29 @@ A wrapper for [github.com/nasa/Common-Metadata-Repository][git_cmr] in python
 
 1. Coding Styles are defined as [PEP 8][pep8].
 2. This project uses the [editorconfig.org][econfig] file .editorconfig 
-3. Use: `pylint *` to check code
+3. Use: `pylint *` or `runme.sh -l` to check code
+
+## Building and Installing
+
+As of this time the CMR library is not hosted on [pypy.org][pypi]. To install the library from a [wheel][wheel] file it will need to be generated locally using the 'runme.sh' script. On a command line, do the following from the python/CMR directory:
+
+    ./runme.sh -p -i
+
+This will create a file like `dist/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl` (version number may very) and install it with pip3. Reviewing the script will show the exact steps to be:
+    
+    python3 setup.py sdist bdist_wheel
+    pip3 install dist/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl
+
+To uninstall the library, use `runme.sh -u`
+
+To run the library without installing it, then try the following in the calling script (where the path is the location of the CMR/python directory inside the git clone directory):
+
+    import sys, os
+    sys.path.append(os.path.expanduser('~/src/project/eo-meta-tools-demo/CMR/python'))
 
 ## Usage
+
+For usage help on the runme.sh command, try: `runme.sh -h` for help.
 
 ### UAT vs Production
 
@@ -24,10 +44,12 @@ For testing and general exploration it is advised that the User Acceptance Testi
     results = coll.search(params, config={'env':'uat'})
 
 ### Testing
-`python3 -m unittest discover`
+Use either `runme.sh -t` or `python3 -m unittest discover`
 
 [pep8]: https://www.python.org/dev/peps/pep-0008/ "Python coding standard"
 [cmr]: https://cmr.earthdata.nasa.gov/ "CMR API"
 [git_cmr]: https://github.com/nasa/Common-Metadata-Repository/ "CMR GitHub Repository"
 [edl]: https://urs.earthdata.nasa.gov/ "Earth Data Login"
 [econfig]: https://editorconfig.org/ "Editor Config Definition"
+[pypi]: https://pypi.org "Python Package Index"
+[wheel]: https://pypi.org/project/wheel/0.25.0/ "What is a Wheel file?"

--- a/CMR/python/demos/collections.ipynb
+++ b/CMR/python/demos/collections.ipynb
@@ -20,12 +20,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.append('/Users/tacherr1/src/project/eo-metadata-tools/CMR/python')"
+    "import sys, os\n",
+    "sys.path.append(os.path.expanduser('~/src/project/eo-meta-tools-demo/CMR/python'))"
    ]
   },
   {
@@ -37,7 +37,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +75,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "results = coll.search({'keyword':'salt'})\n",
@@ -156,7 +158,7 @@
    "outputs": [],
    "source": [
     "params = {}\n",
-    "raw_results = coll.search(params, limit=2, config={'env':'sit'})"
+    "raw_results = coll.search(params, limit=2, config={'env':'uat'})"
    ]
   },
   {
@@ -165,7 +167,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "clean_results = coll.apply_filters([coll.collection_core_fields, coll.drop_fields('EntryTitle')], raw_results)\n",
+    "clean_results = coll.apply_filters([coll.collection_core_fields,coll.drop_fields('EntryTitle')], raw_results)\n",
     "\n",
     "print(\"Found {} records.\".format(len(clean_results)))\n",
     "for i in clean_results:\n",
@@ -201,23 +203,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Getting Help\n",
-    "print out all the docstrings, you can filter by a prefix if you want"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(coll.print_help())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Help with Sort Keys\n",
     "Can not remember the sort keys, look them up"
    ]
@@ -235,7 +220,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "----"
+    "## Getting Help\n",
+    "print out all the docstrings, you can filter by a prefix if you want"
    ]
   },
   {
@@ -243,7 +229,17 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "print(coll.print_help())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "----\n",
+    "EOF"
+   ]
   }
  ],
  "metadata": {

--- a/CMR/python/demos/collections.ipynb
+++ b/CMR/python/demos/collections.ipynb
@@ -15,17 +15,7 @@
    "metadata": {},
    "source": [
     "## Loading the library\n",
-    "This will not be needed once we have the library working through PIP, but today I'm going to use my local checkout."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys, os\n",
-    "sys.path.append(os.path.expanduser('~/src/project/eo-meta-tools-demo/CMR/python'))"
+    "From the command line, make sure you call `runme.sh -p -i` to both backage and install the library through pip3.n"
    ]
   },
   {

--- a/CMR/python/demos/granules.ipynb
+++ b/CMR/python/demos/granules.ipynb
@@ -24,8 +24,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.append('/Users/tacherr1/src/project/eo-metadata-tools/CMR/python')"
+    "import sys, os\n",
+    "sys.path.append(os.path.expanduser('~/src/project/eo-meta-tools-demo/CMR/python'))"
    ]
   },
   {

--- a/CMR/python/demos/granules.ipynb
+++ b/CMR/python/demos/granules.ipynb
@@ -15,24 +15,14 @@
    "metadata": {},
    "source": [
     "## Loading the library\n",
-    "This will not be needed once we have the library working through PIP, but today I'm going to use my local checkout."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import sys, os\n",
-    "sys.path.append(os.path.expanduser('~/src/project/eo-meta-tools-demo/CMR/python'))"
+    "From the command line, make sure you call `runme.sh -p -i` to both backage and install the library through pip3.n"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## import Modules"
+    "## Import Modules"
    ]
   },
   {

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -113,5 +113,4 @@ done
 if [[ $# -eq 0 ]] ; then
     lint
     unit_test
-    doc_all
 fi

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -1,111 +1,117 @@
 #!/bin/bash
 
-# This is a script to document the commands used to check, test, and build this
-#   package.
+# This is a script to document the commands used to run all the code life cycle
+#   stages of the code. These include lint, test, package, install, uninstall,
+#   document, and clean.
 
+# Print out a usage manual
 help()
 {
-    echo ./runme.sh
-    echo "    same as ./runme.sh -l -u"
+    echo 'Run all the code life cycle steps: lint, test, package, install, uninstall, and clean'
+    echo
+    echo 'Usage:'
+    echo '    ./runme.sh -[chlpt] -[i | u]'
+    echo '    ./runme.sh'
+    echo '        same as ./runme.sh -l -t      #list, test'
+    echo '    ./runme.sh -l -t -p -i            #lint, test, package, install'
     echo
 
-    format="%4s %-10s - %-20s\n"
+    format='%4s %-10s - %-30s\n'
     printf "${format}" Flag Name Description
-    printf "${format}" ---- ------- ---------------------
-    printf "${format}" '-h' help "Print out this help message"
-    printf "${format}" '-d' document "Print out this help message"
-    printf "${format}" '-u' 'unit test' "Print out this help message"
-    printf "${format}" '-p' package "Print out this help message"
-    printf "${format}" '-l' lint "Print out this help message"
+    printf "${format}" ---- ---------- ------------------------------
+    printf "${format}" '-c' 'clean' 'Clean up all generated files and directories'
+    printf "${format}" '-h' 'help' 'Print out this help message'
+    printf "${format}" '-i' 'install' 'Install latest wheel file'
+    printf "${format}" '-u' 'uninstall' 'Uninstall the wheel file'
+    printf "${format}" '-l' 'lint' 'Print out this help message'
+    printf "${format}" '-p' 'package' 'Package project into a whl file'
+    printf "${format}" '-t' 'unit test' 'Run the unit tests'
 }
 
+# Check the syntax of the code for PIP8 violations
 lint()
 {
-    printf "*****************************************************************\n"
-    printf "Run pylint to check for common code convention warnings\n"
+    printf '*****************************************************************\n'
+    printf 'Run pylint to check for common code convention warnings\n'
     pylint * \
         --ignore-patterns=".*\.md,.*\.sh,pylintrc,LICENSE,build,dist,eo_metadata_tools_cmr.egg-info"
 }
 
+# Run all the Unit Tests
 unit_test()
 {
-    printf "*****************************************************************\n"
-    printf "Run the unit test for all subdirectories\n"
+    printf '*****************************************************************\n'
+    printf 'Run the unit test for all subdirectories\n'
     python3 -m unittest discover
-}
-
-doc_one()
-{
-    echo $1
-    mkdir -p doc/${1}
-    pydoc3 -w $(find ${1} -depth 1 -name '*.py')
-    #mv -f *.html doc/${1}
-
-    for item in $(find . -depth 1 -name '*.html')
-    do
-        # remove local file paths
-        cat $item | sed 's|<a href=\"file:/.*</a>||' > doc/$1/$item
-        rm $item
-    done
-
-    index_it $1 >> doc/${1}/index.html
-}
-
-doc_all()
-{
-    rm -rf doc
-    doc_one 'cmr/auth'
-    doc_one 'cmr/search'
-    doc_one 'cmr/util'
-    doc_one 'cmr'
-}
-
-index_it()
-{
-    line="%s\n"
-    br="%s<br>\n"
-    printf $line "<!DOCTYPE html>\n<html><head>"
-    printf "\t<title>$1</title>\n"
-    printf $line "<head>\n<body>"
-    printf "<h1>Directory %s</h1>\n"
-    
-    printf "<ul>\n"
-    list=$(find ${1} -d 1 | \
-        grep -v __pycache__ | \
-        grep -v .pyc | \
-        grep -v .DS_Store | \
-        grep -v index.html | \
-        sed "s|$1\/||" | \
-        sed "s|\.py|\.html|")
-    for item in ${list}
-    do
-        printf "\t<li><a href=\"${item}\">${item}</a></li>\n"
-    done
-    printf $line "</ul>"
-
-    printf $file "</body>\n</html>"
 }
 
 # assume that the following has been called:
 # python3 -m pip install --user --upgrade setuptools wheel
 package_project()
 {
+    printf '*****************************************************************\n'
+    printf 'Run python setup to package the project as a wheel\n'
     python3 setup.py sdist bdist_wheel
 }
 
-while getopts "dhlpu" opt
+# lookup library in pip
+find_package()
+{
+    printf '*****************************************************************\n'
+    printf 'Find library in pip\n'
+    pip3 list eo-metadata-tools-cmr | grep eo-metadata-tools-cmr
+}
+
+# call pip to uninstall the library
+uninstall_package()
+{
+    printf '*****************************************************************\n'
+    printf 'Uninstall the project from pip\n'
+    pip3 uninstall eo-metadata-tools-cmr
+}
+
+# Install the newest wheel
+install_package()
+{
+    printf '*****************************************************************\n'
+    printf 'Install the project whl file with pip\n'
+    newest=$(find dist -name "eo_metadata_tools_cmr-*-py3-none-any.whl" -print \
+        | xargs ls -t \
+        | head -n 1)
+    if [ -a ${newest} ] ; then
+        pip3 install ${newest}
+    fi
+}
+
+# Clean up the directory by removing all generated documents and direcorties
+clean()
+{
+    printf '*****************************************************************\n'
+    printf 'Remove all generated files and directories\n'
+    rm -rf build
+    rm -rf dist
+    rm -rf eo_metadata_tools_cmr.egg-info
+}
+
+# Process the command line arguments
+while getopts "cfhilptu" opt
 do
     case ${opt} in
-        d) doc_all ;;
+        c) clean ;;
+        f) find_package ;;
         h) help ;;
-        u) unit_test ;;
-        p) package_project ;;
+        i) install_package ;;
         l) lint ;;
+        p) package_project ;;
+        t) unit_test ;;
+        u) uninstall_package ;;
+        *) help ; exit ;;
     esac
 done
 
-# default, no options given
+# default, no options given, run these tasks
 if [[ $# -eq 0 ]] ; then
     lint
     unit_test
+    doc_all
 fi

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -3,11 +3,109 @@
 # This is a script to document the commands used to check, test, and build this
 #   package.
 
-printf "*********************************************************************\n"
-printf "Run pylint to check for common code convention warnings\n"
-pylint * --ignore-patterns=".*\.md,.*\.sh,pylintrc"
+help()
+{
+    echo ./runme.sh
+    echo "    same as ./runme.sh -l -u"
+    echo
 
-printf "*********************************************************************\n"
-printf "Run the unit test for all subdirectories\n"
-python3 -m unittest discover
+    format="%4s %-10s - %-20s\n"
+    printf "${format}" Flag Name Description
+    printf "${format}" ---- ------- ---------------------
+    printf "${format}" '-h' help "Print out this help message"
+    printf "${format}" '-d' document "Print out this help message"
+    printf "${format}" '-u' 'unit test' "Print out this help message"
+    printf "${format}" '-p' package "Print out this help message"
+    printf "${format}" '-l' lint "Print out this help message"
+}
 
+lint()
+{
+    printf "*****************************************************************\n"
+    printf "Run pylint to check for common code convention warnings\n"
+    pylint * \
+        --ignore-patterns=".*\.md,.*\.sh,pylintrc,LICENSE,build,dist,eo_metadata_tools_cmr.egg-info"
+}
+
+unit_test()
+{
+    printf "*****************************************************************\n"
+    printf "Run the unit test for all subdirectories\n"
+    python3 -m unittest discover
+}
+
+doc_one()
+{
+    echo $1
+    mkdir -p doc/${1}
+    pydoc3 -w $(find ${1} -depth 1 -name '*.py')
+    #mv -f *.html doc/${1}
+
+    for item in $(find . -depth 1 -name '*.html')
+    do
+        # remove local file paths
+        cat $item | sed 's|<a href=\"file:/.*</a>||' > doc/$1/$item
+        rm $item
+    done
+
+    index_it $1 >> doc/${1}/index.html
+}
+
+doc_all()
+{
+    rm -rf doc
+    doc_one 'cmr/auth'
+    doc_one 'cmr/search'
+    doc_one 'cmr/util'
+    doc_one 'cmr'
+}
+
+index_it()
+{
+    line="%s\n"
+    br="%s<br>\n"
+    printf $line "<!DOCTYPE html>\n<html><head>"
+    printf "\t<title>$1</title>\n"
+    printf $line "<head>\n<body>"
+    printf "<h1>Directory %s</h1>\n"
+    
+    printf "<ul>\n"
+    list=$(find ${1} -d 1 | \
+        grep -v __pycache__ | \
+        grep -v .pyc | \
+        grep -v .DS_Store | \
+        grep -v index.html | \
+        sed "s|$1\/||" | \
+        sed "s|\.py|\.html|")
+    for item in ${list}
+    do
+        printf "\t<li><a href=\"${item}\">${item}</a></li>\n"
+    done
+    printf $line "</ul>"
+
+    printf $file "</body>\n</html>"
+}
+
+# assume that the following has been called:
+# python3 -m pip install --user --upgrade setuptools wheel
+package_project()
+{
+    python3 setup.py sdist bdist_wheel
+}
+
+while getopts "dhlpu" opt
+do
+    case ${opt} in
+        d) doc_all ;;
+        h) help ;;
+        u) unit_test ;;
+        p) package_project ;;
+        l) lint ;;
+    esac
+done
+
+# default, no options given
+if [[ $# -eq 0 ]] ; then
+    lint
+    unit_test
+fi

--- a/CMR/python/setup.py
+++ b/CMR/python/setup.py
@@ -15,7 +15,7 @@ setuptools.setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/nasa/eo-metadata-tools/",
-    packages=setuptools.find_packages(),
+    packages=setuptools.find_packages(exclude=['test']),
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: Apache License 2.0",

--- a/CMR/python/setup.py
+++ b/CMR/python/setup.py
@@ -1,0 +1,25 @@
+"""
+Setup file for producing a PIP package
+"""
+import setuptools
+
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
+setuptools.setup(
+    name="eo-metadata-tools-cmr",
+    version="0.0.1",
+    author="Thomas Cherry",
+    author_email="thomas.a.cherry@nasa.gov",
+    description="A python wrapper to the CMR interface",
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    url="https://github.com/nasa/eo-metadata-tools/",
+    packages=setuptools.find_packages(),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "License :: Apache License 2.0",
+        "Operating System :: OS Independent",
+    ],
+    python_requires='>=3.4',
+)


### PR DESCRIPTION
Adding a build and an install step to the rune.sh script.

How to test said change:
Load Library, use pip3 list to see that it is loaded, then run one of the notebooks skipping the step that loads the development path.
