### PR TITLE
CMR-6818 - Change 2 - Now with GitHub instructions

### DIFF
--- a/CMR/python/README.md
+++ b/CMR/python/README.md
@@ -17,7 +17,7 @@ A wrapper for [github.com/nasa/Common-Metadata-Repository][git_cmr] in python
 
 ## Building and Installing
 
-As of this time the CMR library is not hosted on [pypy.org][pypi]. There are several ways to install the library:
+This tool is not presently hosted on [pypy.org][pypi]. There are several ways to install the library:
 
 ### Stable from github:
 
@@ -30,7 +30,7 @@ As of this time the CMR library is not hosted on [pypy.org][pypi]. There are sev
 To install the latest build directly from github, the following command can be.
 used. But be warned, 
 
-    pip3 install 'https://github.com/nasa/eo-metadata-tools/releases/download/latest/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl'{code}
+    pip3 install 'https://github.com/nasa/eo-metadata-tools/releases/download/latest/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl'
 
 ### Install Local Build:
 
@@ -69,7 +69,7 @@ For testing and general exploration it is advised that the User Acceptance Testi
 Use either `runme.sh -t` or `python3 -m unittest discover`
 
 ## Using the runme.sh script
-The runme.sh script documents how to run all the software life cycles for the project like testing, building, and installing. The script takes many flags, the lastest can be viewed by calling `./runme.sh -h`. Below is also a table of these flags. All flags can be called more then once except -h which ends the script.
+The runme.sh script documents how to run all the software stages for the project like testing, building, and installing. The script takes many flags. Below is a table of these flags.
 
 Usage example: `./runme.sh -f -u -f -p -i -f` which means:
 find, uninstall, find, package, install, find
@@ -78,7 +78,7 @@ find, uninstall, find, package, install, find
 | ---- | --------- | -------------------------------------------- |
 | -c   | clean     | Clean up all generated files and directories
 | -f   | find      | Find the package in pip3
-| -h   | help      | Print out this help message
+| -h   | help      | Print out this help message and then exits
 | -i   | install   | Install latest wheel file
 | -u   | uninstall | Uninstall the wheel file
 | -l   | lint      | Print out this help message

--- a/CMR/python/README.md
+++ b/CMR/python/README.md
@@ -30,7 +30,7 @@ This tool is not presently hosted on [pypy.org][pypi]. There are several ways to
 To install the latest build directly from github, the following command can be.
 used. But be warned, 
 
-    pip3 install 'https://github.com/nasa/eo-metadata-tools/releases/download/latest/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl'
+    pip3 install https://github.com/nasa/eo-metadata-tools/releases/download/latest/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl
 
 ### Install Local Build:
 

--- a/CMR/python/README.md
+++ b/CMR/python/README.md
@@ -17,7 +17,26 @@ A wrapper for [github.com/nasa/Common-Metadata-Repository][git_cmr] in python
 
 ## Building and Installing
 
-As of this time the CMR library is not hosted on [pypy.org][pypi]. To install the library from a [wheel][wheel] file it will need to be generated locally using the 'runme.sh' script. On a command line, do the following from the python/CMR directory:
+As of this time the CMR library is not hosted on [pypy.org][pypi]. There are several ways to install the library:
+
+### Stable from github:
+
+***NOTE***: Not yet implemented, as there is not a current stable build yet. When the first version is created, this section will be updated.
+
+### Latest from git hub:
+
+***WARNING***: This will install the latest build and may not be the most stable code!
+
+To install the latest build directly from github, the following command can be.
+used. But be warned, 
+
+    pip3 install 'https://github.com/nasa/eo-metadata-tools/releases/download/latest/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl'{code}
+
+### Install Local Build:
+
+***NOTE***: Preferred method.
+
+To install the library from a local [wheel][wheel] file it will first need to be generated using the 'runme.sh' script. On a command line, run the following from the `python/CMR` directory:
 
     ./runme.sh -p -i
 
@@ -26,7 +45,10 @@ This will create a file like `dist/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl`
     python3 setup.py sdist bdist_wheel
     pip3 install dist/eo_metadata_tools_cmr-0.0.1-py3-none-any.whl
 
+### Uninstalling
 To uninstall the library, use `runme.sh -u`
+
+### Using Library without pip3
 
 To run the library without installing it, then try the following in the calling script (where the path is the location of the CMR/python directory inside the git clone directory):
 
@@ -45,6 +67,26 @@ For testing and general exploration it is advised that the User Acceptance Testi
 
 ### Testing
 Use either `runme.sh -t` or `python3 -m unittest discover`
+
+## Using the runme.sh script
+The runme.sh script documents how to run all the software life cycles for the project like testing, building, and installing. The script takes many flags, the lastest can be viewed by calling `./runme.sh -h`. Below is also a table of these flags. All flags can be called more then once except -h which ends the script.
+
+Usage example: `./runme.sh -f -u -f -p -i -f` which means:
+find, uninstall, find, package, install, find
+
+| Flag | Name      | Description |
+| ---- | --------- | -------------------------------------------- |
+| -c   | clean     | Clean up all generated files and directories
+| -f   | find      | Find the package in pip3
+| -h   | help      | Print out this help message
+| -i   | install   | Install latest wheel file
+| -u   | uninstall | Uninstall the wheel file
+| -l   | lint      | Print out this help message
+| -p   | package   | Package project into a whl file
+| -t   | unit test | Run the unit tests
+
+If no flags are given, then `-l -u` is assumed.
+
 
 [pep8]: https://www.python.org/dev/peps/pep-0008/ "Python coding standard"
 [cmr]: https://cmr.earthdata.nasa.gov/ "CMR API"

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -7,7 +7,7 @@
 # Print out a usage manual
 help()
 {
-    echo 'Run all the code life cycle steps: lint, test, package, install, uninstall, and clean'
+    echo 'Run all the code stages: lint, test, package, install, uninstall, and clean'
     echo
     echo 'Usage:'
     echo '    ./runme.sh -[cfhlpt] -[i | u]'
@@ -21,7 +21,7 @@ help()
     printf "${format}" ---- ---------- ------------------------------
     printf "${format}" '-c' 'clean' 'Clean up all generated files and directories'
     printf "${format}" '-f' 'find' 'Find the package in pip3'
-    printf "${format}" '-h' 'help' 'Print out this help message'
+    printf "${format}" '-h' 'help' 'Print out this help message and then exit'
     printf "${format}" '-i' 'install' 'Install latest wheel file'
     printf "${format}" '-u' 'uninstall' 'Uninstall the wheel file'
     printf "${format}" '-l' 'lint' 'Print out this help message'

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -10,7 +10,7 @@ help()
     echo 'Run all the code life cycle steps: lint, test, package, install, uninstall, and clean'
     echo
     echo 'Usage:'
-    echo '    ./runme.sh -[chlpt] -[i | u]'
+    echo '    ./runme.sh -[cfhlpt] -[i | u]'
     echo '    ./runme.sh'
     echo '        same as ./runme.sh -l -t      #list, test'
     echo '    ./runme.sh -l -t -p -i            #lint, test, package, install'
@@ -20,6 +20,7 @@ help()
     printf "${format}" Flag Name Description
     printf "${format}" ---- ---------- ------------------------------
     printf "${format}" '-c' 'clean' 'Clean up all generated files and directories'
+    printf "${format}" '-f' 'find' 'Find the package in pip3'
     printf "${format}" '-h' 'help' 'Print out this help message'
     printf "${format}" '-i' 'install' 'Install latest wheel file'
     printf "${format}" '-u' 'uninstall' 'Uninstall the wheel file'


### PR DESCRIPTION
Part of the effort with this ticket was to setup building in github, the last pull request allowed a github action to trigger which created artifacts. A python wheel file was one of those artifacts. After testing we found we could install directly from github with the pip3 command (which we were not sure of before). This pull request is for the documentation updates showing how to install using this process.
