### PR TITLE
CMR-6875 python code coverage reports

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Run Unit Tests
         run: ./runme.sh -t
         working-directory: ./CMR/python
+      - name: "Upload coverage to Codecov"
+        uses: codecov/codecov-action@v1
+        working-directory: ./CMR/python
+        with:
+          fail_ci_if_error: true
       - name: Lint
         run: ./runme.sh -l
         working-directory: ./CMR/python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,6 @@ jobs:
         working-directory: ./CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
-        working-directory: ./CMR/python
         with:
           fail_ci_if_error: true
       - name: Lint

--- a/CMR/python/.gitignore
+++ b/CMR/python/.gitignore
@@ -1,0 +1,1 @@
+htmlcov/

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -45,8 +45,10 @@ lint()
 unit_test()
 {
     printf '*****************************************************************\n'
-    printf 'Run the unit test for all subdirectories\n'
-    python3 -m unittest discover
+    printf 'Run the unit tests for all subdirectories\n'
+    pip3 install coverage
+    coverage run -m unittest discover
+    coverage html
 }
 
 # assume that the following has been called:
@@ -94,6 +96,7 @@ clean()
     printf 'Remove generated files and directories\n'
     rm -rf build
     rm -rf dist
+    rm -rf htmlcov
     rm -rf eo_metadata_tools_cmr.egg-info
     find cmr -type d -name '__pycache__' | xargs rm -rf
 }


### PR DESCRIPTION
CMR-6875

Augmenting existing unittests with code coverage reports

Run `./runme.sh -t` to run tests as before. 

Verify coverage reports are generated.
* HTML reports generated locally at `./CMR/python/htmlcov`
* results uploaded to https://codecov.gh/nasa/eo-metadata-tools

`master` build results will be available after merge, see  [commit results](https://codecov.io/gh/nasa/eo-metadata-tools/tree/25da4c7e25da040391ce5ac19660b1ef100a7627) 

