### PR TITLE
CMR-6875 codecov configuration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,6 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          files: ./.coverage
           directory: ./CMR/python/
       - name: Lint
         run: ./runme.sh -l

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,8 +27,8 @@ jobs:
         working-directory: ./CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
-        working-directory: ./CMR/python
         with:
+          directory: CMR/python
           fail_ci_if_error: true
       - name: Lint
         run: ./runme.sh -l

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
         with:
-          directory: CMR/python
           fail_ci_if_error: true
       - name: Lint
         run: ./runme.sh -l

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,9 +23,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Unit Tests
-        run: |
-          pip3 install coverage
-          coverage run -m unittest discover
+        run: ./runme.sh -t
         working-directory: ./CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,8 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
+          files: .coverage
+          directory: ./CMR/python/
       - name: Lint
         run: ./runme.sh -l
         working-directory: ./CMR/python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,13 +23,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Unit Tests
-        run: ./runme.sh -t
+        run: |
+          pip3 install coverage
+          coverage run -m unittest discover
         working-directory: ./CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          directory: ./CMR/python/
       - name: Lint
         run: ./runme.sh -l
         working-directory: ./CMR/python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Unit Tests
-        run: ./runme.sh -t
+        run: |
+          pip3 install coverage
+          coverage run -m unittest discover
         working-directory: ./CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,7 @@ jobs:
       - name: Run Unit Tests
         run: |
           pip3 install coverage
-          coverage run -m unittest discover
-        working-directory: ./CMR/python
+          coverage run --source=CMR/python -m unittest discover -s CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
-          files: .coverage
+          files: ./.coverage
           directory: ./CMR/python/
       - name: Lint
         run: ./runme.sh -l

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
         working-directory: ./CMR/python
       - name: "Upload coverage to Codecov"
         uses: codecov/codecov-action@v1
+        working-directory: ./CMR/python
         with:
           fail_ci_if_error: true
       - name: Lint

--- a/CMR/python/test/cmr/search/test_common.py
+++ b/CMR/python/test/cmr/search/test_common.py
@@ -21,7 +21,7 @@ Test cases for the cmr.auth package
 Author: thomas.a.cherry@nasa.gov - NASA
 Created: 2020-11-30
 """
-
+import os
 from unittest.mock import patch
 import unittest
 import test.cmr as tutil
@@ -185,12 +185,14 @@ class TestSearch(unittest.TestCase):
     @patch('urllib.request.urlopen')
     def test_scroll(self, urlopen_mock):
         """ Test the scroll clear function to see if it returns an error or not"""
-        recorded_data_file = 'test/data/cmr/common/scroll_good.json'
+        recorded_data_file = os.path.join (os.path.dirname (__file__),
+                                           '../../data/cmr/common/scroll_good.json')
         urlopen_mock.return_value = valid_cmr_response(recorded_data_file, 204)
         result = scom.clear_scroll('-1')
         self.assertFalse('errors' in result)
 
-        recorded_data_file = 'test/data/cmr/common/scroll_bad.json'
+        recorded_data_file = os.path.join (os.path.dirname (__file__),
+                                           '../../data/cmr/common/scroll_bad.json')
         urlopen_mock.return_value = valid_cmr_response(recorded_data_file, 404)
         result = scom.clear_scroll('0')
         self.assertTrue('errors' in result)

--- a/CMR/python/test/cmr/search/test_granule.py
+++ b/CMR/python/test/cmr/search/test_granule.py
@@ -23,6 +23,7 @@ Created: 2020-12-01
 """
 
 #from unittest.mock import Mock
+import os
 from unittest.mock import patch
 import unittest
 
@@ -54,7 +55,8 @@ class TestSearch(unittest.TestCase):
         """
         # Setup
         urlopen_mock.return_value = valid_cmr_response(
-            'test/data/cmr/search/one_granule_cmr_result.json')
+            os.path.join (os.path.dirname (__file__), '../../data/cmr/search/one_granule_cmr_result.json')
+        )
 
         # Basic
         full_result = gran.search({'provider':'SEDAC'}, limit=1)

--- a/CMR/python/test/cmr/search/test_search.py
+++ b/CMR/python/test/cmr/search/test_search.py
@@ -21,7 +21,7 @@ Test cases for the cmr.search.search module
 Author: thomas.a.cherry@nasa.gov - NASA
 Created: 2020-10-15
 """
-
+import os
 from unittest.mock import patch
 import unittest
 
@@ -55,7 +55,8 @@ class TestSearch(unittest.TestCase):
         fewer to the caller
         """
         # Setup
-        recorded_data_file = 'test/data/cmr/search/ten_results_from_ghrc.json'
+        recorded_data_file = os.path.join (os.path.dirname (__file__),
+                                           '../../data/cmr/search/ten_results_from_ghrc.json')
         urlopen_mock.return_value = valid_cmr_response(recorded_data_file)
 
         # tests
@@ -69,7 +70,8 @@ class TestSearch(unittest.TestCase):
         def search(query=None, filters=None, limit=None, config=None):
         """
         # Setup
-        recorded_data_file = 'test/data/cmr/search/one_cmr_result.json'
+        recorded_data_file = os.path.join (os.path.dirname (__file__),
+                                           '../../data/cmr/search/one_cmr_result.json')
         urlopen_mock.return_value = valid_cmr_response(recorded_data_file)
 
         full_result = coll.search({'provider':'SEDAC'}, limit=1)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "::CMR/python/" # move the root ;; cmr/<file.py> => CMR/python/cmr/<file.py>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+fixes:
+  - "::CMR/python" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 fixes:
-  - "::CMR/python/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>
+  - "cmr/::CMR/python/cmr/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  disable_default_path_fixes: false
+  
 fixes:
   - "::CMR/python/"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,5 @@
 fixes:
-  - "::CMR/python/cmr"
-  - "cmr/::CMR/python/"
+  - "::CMR/python/"
 
 ignore:
-  - "*/test/*"
+  - "**/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,4 @@
 fixes:
+  - "test/::CMR/python/test/" # move the root test/<file.py> => CMR/python/test/<file.py>
   - "cmr/::CMR/python/cmr/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>
+

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,3 @@
 fixes:
   - "cmr/::CMR/python/cmr/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>
+  - "test/::CMR/python/test/"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,2 @@
 fixes:
-  - "::CMR/python" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>
+  - "::CMR/python/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,0 @@
-fixes:
-  - "test/::CMR/python/test/" # move the root test/<file.py> => CMR/python/test/<file.py>
-  - "cmr/::CMR/python/cmr/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>
-

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,5 @@
 fixes:
   - "::CMR/python/" # move the root ;; cmr/<file.py> => CMR/python/cmr/<file.py>
+
+ignores:
+  - "*/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,2 @@
 fixes:
-  - "cmr/::CMR/python/cmr/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>
-  - "test/::CMR/python/test/"
+  - "::CMR/python/" # move the root cmr/<file.py> => CMR/python/cmr/<file.py>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 fixes:
-  - "::CMR/python/" # move the root ;; cmr/<file.py> => CMR/python/cmr/<file.py>
+  - "*/cmr::CMR/python/cmr" # move the root ;; cmr/<file.py> => CMR/python/cmr/<file.py>
 
 ignores:
   - "*/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,6 @@
 fixes:
   - "::CMR/python/cmr"
+  - "cmr/::CMR/python/"
 
 ignore:
   - "*/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,8 +1,2 @@
-codecov:
-  disable_default_path_fixes: false
-  
-fixes:
-  - "::CMR/python/"
-
 ignore:
   - "**/test/*"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,5 @@
 fixes:
-  - "*/cmr::CMR/python/cmr" # move the root ;; cmr/<file.py> => CMR/python/cmr/<file.py>
+  - "::CMR/python/cmr"
 
-ignores:
+ignore:
   - "*/test/*"


### PR DESCRIPTION
CMR-6875

added codecov.yml file to fix some path changes in codecov

How to test said change
look at the PR branch in codecov and see that the files can be browsed in the correct location from codecov including syntax highlighting for coverage on the code

[codecov commit file browser](https://codecov.io/gh/nasa/eo-metadata-tools/tree/f17c6001543d1fa2b45b22c171e1916a805076b0)

Verify tests continue to run locally
```
cd CMR/python
./runme.sh -t
```

