### PR TITLE
CMR-6899 - EDL Token support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,7 +140,8 @@ cython_debug/
 .idea/
 
 # Other things
-tags
-.swp
-.off
-.backup
+**/tags
+**/*.swp
+**/*.off
+**/off.*
+**/*.backup

--- a/CMR/python/README.md
+++ b/CMR/python/README.md
@@ -67,6 +67,19 @@ For testing and general exploration it is advised that the User Acceptance Testi
 
     results = coll.search(params, config={'env':'uat'})
 
+### Tokens
+If you need to use tokens, use the [EDL Token Generator](https://urs.earthdata.nasa.gov/user_tokens) to create a token. Then if your on a Macintosh, store the token in the `Keychain Access.app` application (found in the Utilities folder) by creating a password. Do this by selecting either `File->New Password Item...` or pressing `command-n`. In the resulting window make the following settings:
+
+* **Name**: `cmr-lib-token`
+* **Account**: `user`
+* **Where**: `cmr lib token`
+* **Comments**: put a note here that this is for the cmr python library and which envirnment the token is foro
+* **Show Password**: put your token here
+
+Save. When you request a token in code, a popup will display asking for your keychain password.
+
+A less secure way to store your token is to save it to a text file at `~/.cmr_token`. The code will use the first line which does not start with `#`.
+
 ### Testing
 Use either `runme.sh -t` or `python3 -m unittest discover`
 
@@ -76,18 +89,19 @@ The runme.sh script documents how to run all the software stages for the project
 Usage example: `./runme.sh -f -u -f -p -i -f` which means:
 find, uninstall, find, package, install, find
 
-| Flag | Name      | Description |
-| ---- | --------- | -------------------------------------------- |
-| -c   | clean     | Clean up all generated files and directories
-| -d   | document  | Generate documentation files
-| -f   | find      | Find the package in pip3
-| -h   | help      | Print out this help message and then exits
-| -i   | install   | Install latest wheel file
-| -u   | uninstall | Uninstall the wheel file
-| -l   | lint      | Print out this help message
-| -p   | package   | Package project into a whl file
-| -r   | report    | Doc-It tag report
-| -t   | unit test | Run the unit tests
+| Flag | Option   | Name      | Description |
+| ---- | -------- | --------- | -------------------------------------------- |
+| -c   |          | clean     | Clean up all generated files and directories
+| -d   |          | document  | Generate documentation files
+| -f   |          | find      | Find the package in pip3
+| -h   |          | help      | Print out this help message and then exits
+| -i   |          | install   | Install latest wheel file
+| -u   |          | uninstall | Uninstall the wheel file
+| -l   |          | lint      | Print out this help message
+| -p   |          | package   | Package project into a whl file
+| -r   |          | report    | Doc-It tag report
+| -t   |          | unit test | Run the unit tests
+| -v   | \<value> | version   | Appends a version number to python and pip commands
 
 If no flags are given, then `-l -u` is assumed.
 

--- a/CMR/python/cmr/auth/token.py
+++ b/CMR/python/cmr/auth/token.py
@@ -121,7 +121,7 @@ def token_manager(config: dict = None):
 
 def token(token_lambdas = None, config: dict = None):
     """
-    Recursively calls lambdas till a token is found. These lamdba functions
+    Loops through the list of lambdas till a token is found. These lamdba functions
     return an EDL token which can be passed to Earthdata software to authenticate
     the user. To get a token, go to https://sit.urs.earthdata.nasa.gov/user_tokens
 

--- a/CMR/python/cmr/auth/token.py
+++ b/CMR/python/cmr/auth/token.py
@@ -82,7 +82,13 @@ def token_file(config: dict = None):
     config = common.always(config)
     path_to_use = config.get('cmr.token.file', '~/.cmr_token')
     path = os.path.expanduser(path_to_use)
-    clear_text = common.read_file(path)
+    clear_text = None
+    raw_clear_text = common.read_file(path)
+    if raw_clear_text is not None:
+        for line in raw_clear_text.splitlines():
+            if not line.startswith("#"):
+                clear_text = line
+                break # we only need the first one
     return clear_text
 
 # document-it: {"key":"token.manager.account", "default":"user"}
@@ -115,7 +121,10 @@ def token_manager(config: dict = None):
 
 def token(token_lambdas = None, config: dict = None):
     """
-    Recursively calls lambdas till a token is found
+    Recursively calls lambdas till a token is found. These lamdba functions
+    return an EDL token which can be passed to Earthdata software to authenticate
+    the user. To get a token, go to https://sit.urs.earthdata.nasa.gov/user_tokens
+
     Parameters:
         token_lambda: a token lambda or a list of functions
         config: Responds to no values

--- a/CMR/python/demos/notebooks/tokens.ipynb
+++ b/CMR/python/demos/notebooks/tokens.ipynb
@@ -14,8 +14,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Practice Demo Safe\n",
-    "Just for this demo, I'm going to create a function that hids some of an EDL token, I don't want anyone to actually see my tokens"
+    "## Practice Demo Safety\n",
+    "Just for this demo, I'm going to create a function that hides some of an EDL token, I don't want anyone to actually see my tokens."
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "source": [
     "## Loading the library\n",
-    "This will not be needed once we have the library working through PIP, but with this a local checkout can be used. In this case, the command `git clone https://github.com/nasa/eo-metadata-tools` was called in `~/src/project`."
+    "This will not be needed once we have the library working through PIP, but with this, a local checkout can be used. In this case, the command `git clone https://github.com/nasa/eo-metadata-tools` was called in `~/src/project`."
    ]
   },
   {
@@ -90,7 +90,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "options = {\"cmr.token.file\": \"~/.cmr_token\"} #this is the default actually\n",

--- a/CMR/python/demos/notebooks/tokens.ipynb
+++ b/CMR/python/demos/notebooks/tokens.ipynb
@@ -14,7 +14,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Demo Safe\n",
+    "## Practice Demo Safe\n",
     "Just for this demo, I'm going to create a function that hids some of an EDL token, I don't want anyone to actually see my tokens"
    ]
   },
@@ -28,10 +28,11 @@
     "    if actual_token is None:\n",
     "        print (\"no token\")\n",
     "        return\n",
-    "    scrub = 5\n",
-    "    strike = \"*\" * scrub\n",
-    "    safe = actual_token[scrub:(len(actual_token)-scrub)]\n",
-    "    print (strike + safe + strike)\n",
+    "    token_len = len(actual_token)\n",
+    "    keep = int(token_len / 4)\n",
+    "    token_len = len(actual_token)\n",
+    "    strike = \"*\" * (token_len-(keep*2))\n",
+    "    print (actual_token[:keep] + strike + actual_token[token_len-keep:])\n",
     "\n",
     "print (\"example:\")\n",
     "safe_token_print(\"012345678909876543210\")"
@@ -42,7 +43,7 @@
    "metadata": {},
    "source": [
     "## Loading the library\n",
-    "This will not be needed once we have the library working through PIP, but today I'm going to use my local checkout."
+    "This will not be needed once we have the library working through PIP, but with this a local checkout can be used. In this case, the command `git clone https://github.com/nasa/eo-metadata-tools` was called in `~/src/project`."
    ]
   },
   {
@@ -51,8 +52,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import sys\n",
-    "sys.path.append('/Users/tacherr1/src/project/eo-metadata-tools/CMR/python/')"
+    "sys.path.append(os.path.expanduser('~/src/project/eo-metadata-tools/CMR/python/'))"
    ]
   },
   {
@@ -60,7 +62,7 @@
    "metadata": {},
    "source": [
     "### Import the library\n",
-    "This should be all you need after we get PIP support"
+    "This should be all you need after we get PIP support. Take care to make sure you install to the same version of python if you have multiple instances."
    ]
   },
   {
@@ -69,7 +71,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import cmr.auth.token as t"
+    "import cmr.auth.token as t\n",
+    "\n",
+    "import platform\n",
+    "print (\"Found in \" + platform.python_version())"
    ]
   },
   {
@@ -77,7 +82,9 @@
    "metadata": {},
    "source": [
     "## Using a token file\n",
-    "In this example we are going to store our password in a file, listed below is how you can specify the file, however the setting is actually the assumed file if no setting is given."
+    "In this example we are going to store our password in a file, listed below is how you can specify the file, however the setting is actually the assumed file if no setting is given.\n",
+    "\n",
+    "To get a token, generate one using the [URS user generated token page](https://urs.earthdata.nasa.gov/user_tokens). Take that token and store it in the file `~/.cmr_token`."
    ]
   },
   {
@@ -89,7 +96,10 @@
     "options = {\"cmr.token.file\": \"~/.cmr_token\"} #this is the default actually\n",
     "safe_token_print(t.token(t.token_file, options))\n",
     "\n",
-    "options = {\"cmr.token.file\": \"~/.cmr_token_fake_file\"} #this is the default actually\n",
+    "options = {} #use no overrides\n",
+    "safe_token_print(t.token(t.token_file, options))\n",
+    "\n",
+    "options = {\"cmr.token.file\": \"~/.cmr_token_fake_file\"} #this is not the default\n",
     "safe_token_print(t.token(t.token_file, options))"
    ]
   },
@@ -98,7 +108,7 @@
    "metadata": {},
    "source": [
     "## Using Keychain on Mac OS X\n",
-    "in this example I am using an already existing password saved securly in keychain. Keychain may require a human to type in the password, I have clicked \"Allways allow\" so we may not see it."
+    "in this example I am using an already existing password saved securly in keychain. Keychain may require a human to type in the password, I have clicked \"Allways allow\" so we may not see it. When using this method, delete the value in `~/.cmr_token` as having a clear text token defeats the security offered by Keychain. "
    ]
   },
   {
@@ -132,6 +142,45 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Now search with a token\n",
+    "Do a very basic search in production using a token. Results **may** very based on the permisions of the user for which the token is for."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cmr.search.collection as coll"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Common settings for both queries\n",
+    "params={'keyword':'modis', 'sort_key': 'instrument'}\n",
+    "filters=[coll.collection_core_fields]\n",
+    "configs1={'env': 'uat'}\n",
+    "\n",
+    "# For the second query a token will be called from keychain and sent as a Bearer token\n",
+    "token = \"Bearer: \" + t.token()\n",
+    "configs2=configs1.copy()\n",
+    "configs2['Authentication'] = token\n",
+    "\n",
+    "print(coll.search(params, filters=filters, config=configs1, limit=2))\n",
+    "print('\\nvs\\n')\n",
+    "safe_token_print(token)\n",
+    "print(coll.search(params, filters=filters, config=configs2, limit=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Bulit in help\n",
     "I can't remember anything, so here is some built in help which pulls from the python docstring for each function of interest"
    ]
@@ -152,13 +201,6 @@
     "----\n",
     "The End"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/CMR/python/demos/scripts/demo.py
+++ b/CMR/python/demos/scripts/demo.py
@@ -9,7 +9,6 @@ try:
     import cmr as cmr_imp
 except ModuleNotFoundError:
     # Try to load the local system
-    print ('using local version')
     import os
     import sys
     sys.path.append(os.path.expanduser('.'))

--- a/CMR/python/demos/scripts/demo.py
+++ b/CMR/python/demos/scripts/demo.py
@@ -9,6 +9,7 @@ try:
     import cmr as cmr_imp
 except ModuleNotFoundError:
     # Try to load the local system
+    print ('using local version')
     import os
     import sys
     sys.path.append(os.path.expanduser('.'))
@@ -40,6 +41,7 @@ def style_input(msg='{}'):
 def main():
     """The commands main method"""
     print ("running version: {}".format(str(cmr_imp.BUILD)))
+    sys.exit()
     print (style_input("Enter in a free text search:"))
     ask = input(">")
     params = {}

--- a/CMR/python/demos/scripts/demo.py
+++ b/CMR/python/demos/scripts/demo.py
@@ -41,7 +41,6 @@ def style_input(msg='{}'):
 def main():
     """The commands main method"""
     print ("running version: {}".format(str(cmr_imp.BUILD)))
-    sys.exit()
     print (style_input("Enter in a free text search:"))
     ask = input(">")
     params = {}

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Assume python3 will be used
+python3=python3
+pip3=pip3
+
 # This is a script to document the commands used to run all the code life cycle
 #   stages of the code. These include lint, test, package, install, uninstall,
 #   document, and clean.
@@ -9,26 +13,28 @@ help()
 {
     echo 'Run all the code stages: lint, test, document, package, install, uninstall, and clean'
     echo
+    echo 'Flags are executed in order and can be called multiple times.'
     echo 'Usage:'
     echo '    ./runme.sh -[cfhlpt] -[i | u]'
     echo '    ./runme.sh'
-    echo '        same as ./runme.sh -l -t      #list, test'
-    echo '    ./runme.sh -l -t -p -i            #lint, test, package, install'
+    echo '        same as ./runme.sh -l -t  #list, test'
+    echo '    ./runme.sh -l -t -p -f -i -f  #lint, test, package, find, install, find'
     echo
 
-    format='%4s %-10s - %-30s\n'
-    printf "${format}" Flag Name Description
-    printf "${format}" ---- ---------- ------------------------------
-    printf "${format}" '-c' 'clean' 'Clean up all generated files and directories'
-    printf "${format}" '-d' 'document' 'Generate documentation files'
-    printf "${format}" '-f' 'find' 'Find the package in pip3'
-    printf "${format}" '-h' 'help' 'Print out this help message and then exit'
-    printf "${format}" '-i' 'install' 'Install latest wheel file'
-    printf "${format}" '-u' 'uninstall' 'Uninstall the wheel file'
-    printf "${format}" '-l' 'lint' 'Print out this help message'
-    printf "${format}" '-p' 'package' 'Package project into a whl file'
-    printf "${format}" '-r' 'report' 'Doc-It tag report'
-    printf "${format}" '-t' 'unit test' 'Run the unit tests'
+    format='%4s %-7s %9s : %-30s\n'
+    printf "${format}" Flag Value Name Description
+    printf "${format}" ---- ------- --------- ----------------------------------
+    printf "${format}" '-c' '' 'clean' 'Clean up all generated files and directories'
+    printf "${format}" '-d' '' 'document' 'Generate documentation files'
+    printf "${format}" '-f' '' 'find' "Find the package in $pip3"
+    printf "${format}" '-h' '' 'help' 'Print out this help message and then exit'
+    printf "${format}" '-i' '' 'install' 'Install latest wheel file'
+    printf "${format}" '-l' '' 'lint' 'Print out this help message'
+    printf "${format}" '-p' '' 'package' 'Package project into a whl file'
+    printf "${format}" '-r' '' 'report' 'Doc-It tag report'
+    printf "${format}" '-t' '' 'test' 'Run the unit tests'
+    printf "${format}" '-u' '' 'uninstall' 'Uninstall the wheel file'
+    printf "${format}" '-v' '<value>' 'version' 'Appends a version number to python and pip commands'
 }
 
 # Check the syntax of the code for PIP8 violations
@@ -45,8 +51,12 @@ lint()
 unit_test()
 {
     printf '*****************************************************************\n'
-    printf 'Run the unit test for all subdirectories\n'
-    python3 -m unittest discover
+    #printf 'Run the unit test for all subdirectories\n'
+    #python3 -m unittest discover
+    printf 'Run the unit tests for all subdirectories\n'
+    $pip3 install coverage
+    coverage run --source=cmr -m unittest discover
+    coverage html
 }
 
 # assume that the following has been called:
@@ -55,15 +65,15 @@ package_project()
 {
     printf '*****************************************************************\n'
     printf 'Run python setup to package the project as a wheel\n'
-    python3 setup.py sdist bdist_wheel
+    $python3 setup.py sdist bdist_wheel
 }
 
 # lookup library in pip
 find_package()
 {
     printf '*****************************************************************\n'
-    printf 'Find library in pip\n'
-    pip3 list eo-metadata-tools-cmr | grep eo-metadata-tools-cmr
+    printf "Find library in $(which $pip3)\n"
+    $pip3 list eo-metadata-tools-cmr | grep eo-metadata-tools-cmr
 }
 
 # call pip to uninstall the library
@@ -71,7 +81,7 @@ uninstall_package()
 {
     printf '*****************************************************************\n'
     printf 'Uninstall the project from pip\n'
-    pip3 uninstall eo-metadata-tools-cmr
+    $pip3 uninstall eo-metadata-tools-cmr
 }
 
 # Install the newest wheel
@@ -83,7 +93,7 @@ install_package()
         | xargs ls -t \
         | head -n 1)
     if [ -a ${newest} ] ; then
-        pip3 install ${newest}
+        $pip3 install ${newest}
     fi
 }
 
@@ -106,7 +116,7 @@ document_markdown()
     module=cmr
     
     if [ -z "$(which pydoc-markdown)" ] ; then
-        pip3 install pydoc-markdown
+        $pip3 install pydoc-markdown
     fi
     pydoc-markdown
 }
@@ -114,11 +124,18 @@ document_markdown()
 config_report()
 {
     #grep -ri 'Document-it' cmr | sed -e 's/.*Document-it \({.*}\)/\1/g' | jq -c
-    python3 docit.py > doc/config_properties.md
+    $python3 docit.py > doc/config_properties.md
+}
+
+set_version()
+{
+    python3="python$1"
+    pip3="pip$1"
+    echo "NOTE: Using $python3 and $pip3 commands."
 }
 
 # Process the command line arguments
-while getopts "cdfhilprtu" opt
+while getopts "cdfhilprtuv:" opt
 do
     case ${opt} in
         c) clean ;;
@@ -131,6 +148,7 @@ do
         r) config_report ;;
         t) unit_test ;;
         u) uninstall_package ;;
+        v) set_version $OPTARG ;;
         *) help ; exit ;;
     esac
 done

--- a/CMR/python/test/cmr/auth/test_token.py
+++ b/CMR/python/test/cmr/auth/test_token.py
@@ -102,12 +102,12 @@ class TestToken(unittest.TestCase):
         token_file = "/tmp/__test_token_file__.txt"
         util.delete_file(token_file)
         expected_token = "file-token"
-        token_content = "#ignore this line\n" + expected_token
-        common.write_file(token_file, token_content)
+        token_file_content = "#ignore this line\n" + expected_token
+        common.write_file(token_file, token_file_content)
 
         #tests
         actual_token = common.read_file(token_file)
-        self.assertEqual(token_content, actual_token)
+        self.assertEqual(token_file_content, actual_token)
 
         options = {'cmr.token.file': token_file}
         self.assertEqual (expected_token, token.token_file(options))

--- a/CMR/python/test/cmr/auth/test_token.py
+++ b/CMR/python/test/cmr/auth/test_token.py
@@ -92,6 +92,32 @@ class TestToken(unittest.TestCase):
         #cleanup
         util.delete_file(token_file)
 
+    def test_token_file_ignoring_comments(self):
+        """
+        Test a valid login using the password file lambda. The file itself will
+        contain comments to be ignored. This test will require that the test be
+        able to write to a temp directory
+        """
+        #setup
+        token_file = "/tmp/__test_token_file__.txt"
+        util.delete_file(token_file)
+        expected_token = "file-token"
+        token_content = "#ignore this line\n" + expected_token
+        common.write_file(token_file, token_content)
+
+        #tests
+        actual_token = common.read_file(token_file)
+        self.assertEqual(token_content, actual_token)
+
+        options = {'cmr.token.file': token_file}
+        self.assertEqual (expected_token, token.token_file(options))
+
+        actual = str(token.token(token.token_file, options))
+        self.assertEqual (expected_token, actual)
+
+        #cleanup
+        util.delete_file(token_file)
+
     @patch('cmr.util.common.execute_command')
     def test_password_manager(self, cmd_mock):
         """ Test a valid login using the password manager """


### PR DESCRIPTION
CMR-6899 : Adding documentation about using EDL tokens and allowed token file to have comments, added jupyter notebook test

The code was already working with the new EDL tokens but no documentation existing. Also added the ability to comment out tokens in the token file making it easy to have SIT, UAT, and OPS tokens all at once.

To try out this code and too see more information on it, try the token notebook.
