### PR TITLE
Add pyQuARC as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "pyQuARC"]
-	path = pyQuARC
-	url = git@github.com:nasa-impact/pyQuARC.git
-	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "pyQuARC"]
 	path = pyQuARC
-	url = git@github.com:nasa-impact/pyQuARC.git
+	url = https://github.com/nasa-impact/pyQuARC.git
 	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "pyQuARC"]
+	path = pyQuARC
+	url = git@github.com:nasa-impact/pyQuARC.git
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pyQuARC"]
+	path = pyQuARC
+	url = git@github.com:nasa-impact/pyQuARC.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "pyQuARC"]
 	path = pyQuARC
 	url = git@github.com:nasa-impact/pyQuARC.git
+	branch = master


### PR DESCRIPTION
A reference to a related issue ticket number

Changes added:
1. Add gitmodules
2. Add pyQuARC as gitmodules; https://github.com/NASA-IMPACT/pyQuARC

How to test said change:
1. Navigate to the pyQuARC folder
2. All the files from the recent commit in the aforementioned repository should be there.
3. All git operations will be directed to the pyQuARC repository.
4. Tests can be ran using `pytest`
