### PR TITLE
CMR-7362 - Adding scrolling example

### DIFF
--- a/CMR/python/cmr/util/common.py
+++ b/CMR/python/cmr/util/common.py
@@ -147,9 +147,10 @@ def help_format_lambda(contains=""):
 
 def mask_dictionary(data, keys):
     """
-    Prevent sensitive information from being printed by masking part of a
-    dictionaries content
-    Return a copy of the
+    Prevent sensitive information from being printed by masking values of listed
+    keys in a dictionaries. The middle third of the values will be replaced with
+    '*'. Uses Dictionaries copy() function.
+    Return a shallow copy of the data dictionary that has been updated
     """
     if isinstance(keys, str):
         keys = [keys]

--- a/CMR/python/cmr/util/common.py
+++ b/CMR/python/cmr/util/common.py
@@ -98,9 +98,9 @@ def read_file(path):
     """
     text = None
     if os.path.isfile(path):
-        file = open(path, "r")
-        text = file.read().strip()
-        file.close()
+        with open(path, "r") as file:
+            text = file.read().strip()
+            file.close()
     return text
 
 def write_file(path, text):
@@ -111,9 +111,9 @@ def write_file(path, text):
         text (string): content for file
     """
     path = os.path.expanduser(path)
-    cache = open(path, "w+")
-    cache.write(text)
-    cache.close()
+    with open(path, "w+") as cache:
+        cache.write(text)
+        cache.close()
 
 def execute_command(cmd):
     """
@@ -144,3 +144,19 @@ def help_format_lambda(contains=""):
     # n=name, c=content ; made short to keep line length down and pylint happy
     out = lambda n, c : (layout.format(n, c.__doc__.strip())) if contains in n else ""
     return out
+
+def mask_dictionary(data, keys):
+    """
+    Prevent sensitive information from being printed by masking part of a
+    dictionaries content
+    Return a copy of the
+    """
+    if isinstance(keys, str):
+        keys = [keys]
+    safe_data = data.copy()
+    for key in keys:
+        if key in data:
+            unsafe_value = data[key]
+            mask = int(len(unsafe_value)/3)
+            safe_data[key] = unsafe_value[:mask] + ("*"*mask) + unsafe_value[-1*mask:]
+    return safe_data

--- a/CMR/python/demos/notebooks/tokens.ipynb
+++ b/CMR/python/demos/notebooks/tokens.ipynb
@@ -190,7 +190,7 @@
     "# For the second query a token will be called from keychain and sent as a Bearer token\n",
     "token = \"Bearer: \" + t.token()\n",
     "configs2=configs1.copy()\n",
-    "configs2['Authentication'] = token\n",
+    "configs2['cmr-token'] = token\n",
     "\n",
     "print(coll.search(params, filters=filters, config=configs1, limit=2))\n",
     "print('\\nvs\\n')\n",

--- a/CMR/python/demos/scripts/scroll.py
+++ b/CMR/python/demos/scripts/scroll.py
@@ -1,0 +1,63 @@
+"""
+Demonstrate how to perform a scroll call to CMR
+"""
+
+import cmr.util.network as net
+
+def get_block_of_records(search, scroll_id=None):
+    """
+    Recursive function to return records from CMR using scroll. The first time
+    The function is called, just send a dictionary of what your looking for.
+    This function will call itself as many times as needed to collect all the
+    records and return them in a list. When calling recursively, send the
+    scroll id
+    """
+    url = "https://cmr.uat.earthdata.nasa.gov/search/collections.umm_json"
+    accept = "application/vnd.nasa.cmr.umm_results+json"
+    body = search.copy()
+    if scroll_id is None:
+        # first time here, request a scroll id and clear out headers
+        body.update({"scroll": "true", "page_size": "50"})
+        headers = {}
+    else:
+        # recursive call, set the scroll id and don't touch the body
+        headers = {"CMR-Scroll-Id": str(scroll_id)}
+
+    result = net.post(url, body, accept=accept, headers=headers)
+    items = result.get("items", [])
+    count = len(items)  # will be zero if we are at the end
+    resp_headers = result.get("http-headers", {})
+    scroll_id = resp_headers.get("CMR-Scroll-Id", "")
+    results = []
+
+    if count > 0:
+        # probably not done yet, try one more time. This time, send the scroll id
+        results = get_block_of_records(search, scroll_id=scroll_id)
+        results.extend(items)   # add the recursive call records to this calls
+    else:
+        # no records came back, work is done, tell CMR it can clear scroll
+        url_clear = "https://cmr.uat.earthdata.nasa.gov/search/clear-scroll"
+        headers['Content-Type'] = 'application/json'
+        data = '{"scroll_id": "' + str(scroll_id) + '"}'
+        net.post(url_clear, data, accept=None, headers=headers)
+    return results
+
+def main():
+    """
+    Test the function and verify that it is returning unique records
+    """
+    records = get_block_of_records({"keyword": "food"})
+    print ("returned items: {}".format(len(records)))
+
+    processed_records = {}
+    for item in records:
+        meta = item["meta"]
+        umm = item["umm"]
+        cid = meta["concept-id"]
+        short_name = umm["ShortName"]
+        processed_records[cid] = short_name
+
+    print ("uniq keys: {}".format(len(processed_records.keys())))
+
+if __name__ == '__main__':
+    main()

--- a/CMR/python/test/cmr/search/test_granule.py
+++ b/CMR/python/test/cmr/search/test_granule.py
@@ -55,7 +55,8 @@ class TestSearch(unittest.TestCase):
         """
         # Setup
         urlopen_mock.return_value = valid_cmr_response(
-            os.path.join (os.path.dirname (__file__), '../../data/cmr/search/one_granule_cmr_result.json')
+            os.path.join (os.path.dirname (__file__),
+                '../../data/cmr/search/one_granule_cmr_result.json')
         )
 
         # Basic

--- a/CMR/python/test/cmr/util/test_common.py
+++ b/CMR/python/test/cmr/util/test_common.py
@@ -64,3 +64,30 @@ class TestSearch(unittest.TestCase):
         self.assertEqual([], com.always(None, otype=list), 'None, list')
         self.assertEqual((), com.always(None, otype=tuple), 'None, tuple')
         self.assertEqual((), com.always(None, tuple), 'None, tuple, positional')
+
+    def test_mask_dictionary(self):
+        """Test that the mask_diictionary function will clean out sensitive info"""
+        data = {'ignore': 'this',
+            'token': '012345687', 'cmr-token': 'EDL-U12345678901234567890'}
+        expected1 = {'ignore': 'this',
+            'token': '012345687', 'cmr-token': 'EDL-U123********34567890'}
+        expected2 = {'ignore': 'this',
+            'token': '012***687', 'cmr-token': 'EDL-U12345678901234567890'}
+        expected3 = {'ignore': 'this',
+            'token': '012345687', 'cmr-token': 'EDL-U12345678901234567890'}
+        expected4 = {'ignore': 'this',
+            'token': '012***687', 'cmr-token': 'EDL-U123********34567890'}
+
+        self.assertEqual(expected1, com.mask_dictionary(data, 'cmr-token'))
+        self.assertEqual(expected1, com.mask_dictionary(data, ['cmr-token']))
+
+        self.assertEqual(expected2, com.mask_dictionary(data, 'token'))
+        self.assertEqual(expected2, com.mask_dictionary(data, ['token']))
+
+        self.assertEqual(expected3, com.mask_dictionary(data, 'cmr'))
+        self.assertEqual(expected3, com.mask_dictionary(data, ['cmr']))
+
+        self.assertEqual(expected4, com.mask_dictionary(data, ['token', 'cmr-token']))
+
+        self.assertEqual(data, com.mask_dictionary(data, ''))
+        self.assertEqual(data, com.mask_dictionary(data, []))


### PR DESCRIPTION
Adding a script which demonstrates how to do a scrolling query against CMR.
Other changes:
* adding logging used while developing and a function to ensure that tokens are not printed in clear text
* other pylint (using with) changes
* Found misleading info in the token example notebook

The script can be run with: 

    >python3 ./demos/scripts/scroll.py         
    returned items: 214
    uniq keys: 214

