### PR TITLE
CMR-7405 - Bearer Token

### DIFF
--- a/CMR/python/README.md
+++ b/CMR/python/README.md
@@ -80,8 +80,15 @@ If you need to use tokens, use the [EDL Token Generator](https://urs.earthdata.n
 
 Save. When you request a token in code, a popup will display asking for your keychain password.
 
-A less secure way to store your token is to save it to a text file at `~/.cmr_token`. The code will use the first line which does not start with `#`.
+A less secure way to store your token is to save it to a text file at `~/.cmr_token`. The code will use the first line which does not start with `#`. For non-production environments you can save the token to `~/.cmr-token.uat` or `~/.cmr-token.sit`. Once your token is saved, you can have it included in your queries by calling the following:
 
+    import cmr.search.collection as coll
+    import cmr.auth.token as t
+    coll.search({'keyword':'modis'},
+        config=t.use_bearer_token(config={'env': 'uat'}))
+
+This example shows how to use a token stored in `~/.cmr-token.uat` against the UAT version of CMR.
+ 
 ### Testing
 Use either `runme.sh -t` or `python3 -m unittest discover`
 

--- a/CMR/python/cmr/auth/token.py
+++ b/CMR/python/cmr/auth/token.py
@@ -68,19 +68,59 @@ def token_config(config: dict = None):
     value = config.get('cmr.token.value', None)
     return value
 
+# document-it: {"key":"env", "default":"", "msg":"uat, ops, prod, production, or blank for ops"}
+def _env_to_extention(config: dict = None):
+    """
+    Allow different files to be loaded for each environment, make an env
+    extension which will be appended to the token file path
+    Parameters:
+        config dictionary containing an env value
+    Return:
+        empty string or a dot followed by the environment.
+    """
+    config = common.always(config)
+
+    env = config.get('env', '')
+    if env is None:
+        env = ''
+    env = env.lower().strip()
+    if len(env)>0 and env.endswith("."):
+        env += env[:-1]
+    if env in ['', 'ops', 'prod', 'production']:
+        env = "" # no extension
+    else:
+        env = "." + env
+    return env
 
 # document-it: {"key":"cmr.token.file", "default":"~/.cmr_token"}
+# document-it: {"from":"._env_to_extention"}
+def _token_file_path(config: dict = None):
+    """
+    Return the path to the file which stores a CMR token. This path can be different
+    for each environment if specified with the env config.
+    Returns
+        ~/.cmr_token<.env>, no env if production
+    """
+    config = common.always(config)
+    env_extention = _env_to_extention(config)
+    path_to_use = config.get('cmr.token.file', '~/.cmr_token' + env_extention)
+    return path_to_use
+
+# document-it: {"from":".token_file_path"}
 def token_file(config: dict = None):
     """
     Load a token from a local user file assumed to be ~/.cmr_token
     Parameters:
         config: Responds to:
             "cmr.token.file": location of token file, defaults to ~/.cmr_token
+                for production, followed by a dot and the environment name if
+                specified.
+            "env": if not production, appended to the end of ~/.cmr_token with a dot
     Returns
         token from file
     """
-    config = common.always(config)
-    path_to_use = config.get('cmr.token.file', '~/.cmr_token')
+    path_to_use = _token_file_path(config)
+
     path = os.path.expanduser(path_to_use)
     clear_text = None
     raw_clear_text = common.read_file(path)
@@ -118,6 +158,42 @@ def token_manager(config: dict = None):
 
 # ##############################################################################
 # functions
+
+def use_bearer_token(token_lambdas = None, config:dict = None):
+    """
+    Create a new config dictionary, optionally based on a supplied one, and add
+    the bearer token to the config object abstracting away as many details as
+    possible.
+    Parameters:
+        token_lambda: a token lambda or a list of functions
+        config: config dictionary to base new dictionary off of
+    Returns:
+        new config dictionary with Bearer token assigned as an 'authorization'
+    """
+    if config is None:
+        config = {}
+    augmented_config = config.copy()
+    bearer_token = bearer(token_lambdas, config)
+    augmented_config["authorization"] = bearer_token
+    return augmented_config
+
+def bearer(token_lambdas = None, config: dict = None):
+    """
+    Loops through the list of lambdas till a token is found. These lamdba functions
+    return an EDL token which can be passed to Earthdata software to authenticate
+    the user. To get a token, go to https://sit.urs.earthdata.nasa.gov/user_tokens
+    Token is returned as a Bearer String
+
+    Parameters:
+        token_lambda: a token lambda or a list of functions
+        config: Responds to no values
+    Returns:
+        the EDL Bearer Token from the token lambda
+    """
+    token_value = token(token_lambdas, config)
+    if token_value is not None and len(token_value)>0:
+        token_value = "Bearer " + token_value
+    return token_value
 
 def token(token_lambdas = None, config: dict = None):
     """

--- a/CMR/python/cmr/auth/token.py
+++ b/CMR/python/cmr/auth/token.py
@@ -85,7 +85,7 @@ def _env_to_extention(config: dict = None):
         env = ''
     env = env.lower().strip()
     if len(env)>0 and env.endswith("."):
-        env += env[:-1]
+        env = env[:-1]
     if env in ['', 'ops', 'prod', 'production']:
         env = "" # no extension
     else:

--- a/CMR/python/cmr/search/common.py
+++ b/CMR/python/cmr/search/common.py
@@ -122,6 +122,7 @@ def _standard_headers_from_config(config: dict):
     """
     headers = None
     headers = net.config_to_header(config, 'cmr-token', headers, 'Echo-Token')
+    headers = net.config_to_header(config, 'authorization', headers, 'Authorization')
     headers = net.config_to_header(config, 'X-Request-Id', headers)
     headers = net.config_to_header(config, 'Client-Id', headers, default='python_cmr_lib')
     headers = net.config_to_header(config, 'User-Agent', headers, default='python_cmr_lib')
@@ -148,7 +149,7 @@ def _cmr_query_url(base: str, query: dict, page_state: dict, config: dict = None
 def _cmr_basic_url(base: str, query: dict, config: dict = None):
     """
     Create a url for calling any CMR search end point, should not make any
-    assumption, beyond the search directory. Will auto set the envirnment based
+    assumption, beyond the search directory. Will auto set the environment based
     on how config is set
     Parameters:
         base: CMR endpoint
@@ -188,6 +189,12 @@ def _make_search_request(base: str, query: dict, page_state: dict, config: dict)
     """
     # Build headers
     headers = _standard_headers_from_config(config)
+
+    if 'Echo-Token' in headers:
+        logger.info('Using a CMR-Token')
+    if 'Authorization' in headers:
+        logger.info('Using an Authorization token')
+
     if 'CMR-Scroll-Id' in page_state:
         logger.debug('Setting scroll id to %s.', page_state['CMR-Scroll-Id'])
         headers = common.conj(headers, {'CMR-Scroll-Id': page_state['CMR-Scroll-Id']})

--- a/CMR/python/cmr/util/common.py
+++ b/CMR/python/cmr/util/common.py
@@ -145,6 +145,13 @@ def help_format_lambda(contains=""):
     out = lambda n, c : (layout.format(n, c.__doc__.strip())) if contains in n else ""
     return out
 
+def mask_string(unsafe_value):
+    """Prevent sensitive information from being printed by masking values """
+    if unsafe_value is None:
+        return ""
+    mask = int(len(unsafe_value)/3)
+    return unsafe_value[:mask] + ("*"*mask) + unsafe_value[-1*mask:]
+
 def mask_dictionary(data, keys):
     """
     Prevent sensitive information from being printed by masking values of listed
@@ -157,7 +164,7 @@ def mask_dictionary(data, keys):
     safe_data = data.copy()
     for key in keys:
         if key in data:
-            unsafe_value = data[key]
+            unsafe_value = data.get(key, "")
             mask = int(len(unsafe_value)/3)
             safe_data[key] = unsafe_value[:mask] + ("*"*mask) + unsafe_value[-1*mask:]
     return safe_data

--- a/CMR/python/cmr/util/network.py
+++ b/CMR/python/cmr/util/network.py
@@ -161,7 +161,7 @@ def post(url, body, accept=None, headers=None):
             for head in resp.getheaders():
                 head_list[head[0]] = head[1]
             if logger.getEffectiveLevel() == logging.DEBUG:
-                stringified = str(common.mask_dictionary(head_list, "cmr-token"))
+                stringified = str(common.mask_dictionary(head_list, ["cmr-token", "authorization"]))
                 logger.debug(" CMR->Headers = %s", stringified)
             obj_json['http-headers'] = head_list
         elif resp.status == 204:

--- a/CMR/python/demos/notebooks/tokens.ipynb
+++ b/CMR/python/demos/notebooks/tokens.ipynb
@@ -14,34 +14,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Practice Demo Safety\n",
-    "Just for this demo, I'm going to create a function that hides some of an EDL token, I don't want anyone to actually see my tokens."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def safe_token_print(actual_token):\n",
-    "    if actual_token is None:\n",
-    "        print (\"no token\")\n",
-    "        return\n",
-    "    token_len = len(actual_token)\n",
-    "    keep = int(token_len / 4)\n",
-    "    token_len = len(actual_token)\n",
-    "    strike = \"*\" * (token_len-(keep*2))\n",
-    "    print (actual_token[:keep] + strike + actual_token[token_len-keep:])\n",
-    "\n",
-    "print (\"example:\")\n",
-    "safe_token_print(\"012345678909876543210\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Loading the library \n",
     "Do one of the following, but not both"
    ]
@@ -100,8 +72,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Using a token file\n",
-    "In this example we are going to store our password in a file, listed below is how you can specify the file, however the setting is actually the assumed file if no setting is given.\n",
+    "## Printing Tokens - Demo Safety\n",
+    "When working with tokens, you don't want to print them out on the screen, but you might want to look at the value to confirm which token your working with. Use the built in utility function in the utility package to mask out these values for printing to a notebook. This is very importent when sharing your screen."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import cmr.util.common as com\n",
+    "\n",
+    "print (\"examples:\")\n",
+    "print (com.mask_string(\"012345678909876543210\"))\n",
+    "print(com.mask_dictionary({\"token\": \"012345678909876543210\"}, \"token\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Using a token file\n",
+    "\n",
+    "\n",
+    "## Shortest Example\n",
+    "Here is the shortest, one line example of doing a search with a saved bearer token. Grab a UAT token from [UAT URS user generated token page](https://uat.urs.earthdata.nasa.gov/user_tokens) and save it to a file called ~/.cmr_token.uat."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coll.search({'keyword':'modis'},\n",
+    "            filters=[coll.collection_core_fields],\n",
+    "            config=t.use_bearer_token(config={'env': 'uat'}))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## More details on using a token file\n",
+    "In this example we are going to store our token to a file, listed below is how you can specify the file, however the setting is actually the same as the default file if no setting is given.\n",
     "\n",
     "To get a token, generate one using the [URS user generated token page](https://urs.earthdata.nasa.gov/user_tokens). Take that token and store it in the file `~/.cmr_token`."
    ]
@@ -114,14 +129,14 @@
    },
    "outputs": [],
    "source": [
-    "options = {\"cmr.token.file\": \"~/.cmr_token\"} #this is the default actually\n",
-    "safe_token_print(t.token(t.token_file, options))\n",
+    "config = {} #use no overrides\n",
+    "print(\"token: '%s'\" % com.mask_string(t.token(t.token_file, config)))\n",
     "\n",
-    "options = {} #use no overrides\n",
-    "safe_token_print(t.token(t.token_file, options))\n",
+    "config = {\"cmr.token.file\": \"~/.cmr_token\"} #this is the same as the default\n",
+    "print(\"token: '%s'\" % com.mask_string(t.token(t.token_file, config)))\n",
     "\n",
-    "options = {\"cmr.token.file\": \"~/.cmr_token_fake_file\"} #this is not the default\n",
-    "safe_token_print(t.token(t.token_file, options))"
+    "config = {\"cmr.token.file\": \"~/.cmr_token_fake_file\"} #this is not the default\n",
+    "print(\"token: '%s'\" % com.mask_string(t.token(t.token_file, config)))"
    ]
   },
   {
@@ -139,7 +154,7 @@
    "outputs": [],
    "source": [
     "options = {'token.manager.service': 'cmr lib token'} #this is not the default\n",
-    "safe_token_print(t.token(t.token_manager, options))"
+    "print(com.mask_string(t.token(t.token_manager, options)))"
    ]
   },
   {
@@ -156,7 +171,7 @@
    "outputs": [],
    "source": [
     "options = {\"cmr.token.file\": \"~/.cmr_token_fake_file\", 'token.manager.service': 'cmr lib token'}\n",
-    "safe_token_print(t.token([t.token_manager, t.token_file], options))"
+    "print(com.mask_string(t.token([t.token_manager, t.token_file], options)))"
    ]
   },
   {
@@ -164,7 +179,11 @@
    "metadata": {},
    "source": [
     "## Now search with a token\n",
-    "Do a very basic search in production using a token. Results **may** very based on the permisions of the user for which the token is for."
+    "Do a very basic search in production using a token. Results **may** very based on the permisions of the user for which the token is for. This example will use the function called \"use_bearer_token\" which will create a new configuration dictionary with your token information added to it. Your new configuration can be copied from an existing configuration dictionary if you have one. If saving your token to a file, nothing needs else needs to happen.\n",
+    "\n",
+    "`new_config = t.use_bearer_token(config=old_config)`\n",
+    "\n",
+    "This example will also show how to turn on logging to get more details out of the internal code.\n"
    ]
   },
   {
@@ -183,19 +202,19 @@
    "outputs": [],
    "source": [
     "# Common settings for both queries\n",
-    "params={'keyword':'modis', 'sort_key': 'instrument'}\n",
-    "filters=[coll.collection_core_fields]\n",
-    "configs1={'env': 'uat'}\n",
+    "params={'keyword':'modis', 'sort_key':'instrument'} #something to search for\n",
+    "filters=[coll.collection_core_fields] #reduce the values displayed\n",
+    "configs1={} # use all defaults\n",
     "\n",
     "# For the second query a token will be called from keychain and sent as a Bearer token\n",
-    "token = \"Bearer: \" + t.token()\n",
-    "configs2=configs1.copy()\n",
-    "configs2['cmr-token'] = token\n",
+    "configs2=t.use_bearer_token(config=configs1)\n",
+    "coll.set_logging_to(\"INFO\") #logging on\n",
     "\n",
     "print(coll.search(params, filters=filters, config=configs1, limit=2))\n",
     "print('\\nvs\\n')\n",
-    "safe_token_print(token)\n",
-    "print(coll.search(params, filters=filters, config=configs2, limit=2))"
+    "print(com.mask_string(configs2['authorization']))\n",
+    "print(coll.search(params, filters=filters, config=configs2, limit=2))\n",
+    "coll.set_logging_to(\"ERROR\") #effectivly, logging off"
    ]
   },
   {

--- a/CMR/python/test/cmr/auth/test_token.py
+++ b/CMR/python/test/cmr/auth/test_token.py
@@ -92,6 +92,56 @@ class TestToken(unittest.TestCase):
         #cleanup
         util.delete_file(token_file)
 
+    def test_bearer(self):
+        """Test a that a token can be returned as a Bearer token"""
+        #setup
+        token_file = "/tmp/__test_token_file__.txt"
+        util.delete_file(token_file)
+        expected_token = "file-token"
+        expected_bearer = "Bearer " + expected_token
+        common.write_file(token_file, expected_token)
+
+        #tests
+        options = {'cmr.token.file': token_file}
+        actual = str(token.bearer(token.token_file, options))
+        self.assertEqual (expected_bearer, actual, "Token formated as Bearer")
+
+        #cleanup
+        util.delete_file(token_file)
+
+    # pylint: disable=W0212 ; test a private function
+    def test__env_to_extention(self):
+        """Check that the environment->extensions work as expected"""
+        # pylint: disable=C0301 # lambdas must be on one line
+        test = lambda expected, given, msg : self.assertEqual(expected, token._env_to_extention(given), msg)
+
+        test("", None, "No dictionary given")
+        test("", {}, "Empty dictionary")
+        test("", {"env":None}, "Emtpy value")
+        test("", {"env":""}, "Blank value")
+        test("", {"env":"ops"}, "Ops specified")
+        test("", {"env":"prod"}, "Production specified")
+        test("", {"env":"production"}, "Production specified")
+        test(".uat", {"env":"uat"}, "UAT specified")
+        test(".sit", {"env":"sit"}, "SIT specified")
+        test(".future", {"env":"future"}, "Future envirnment")
+
+    # pylint: disable=W0212 ; test a private function
+    def test_token_file_env(self):
+        """Test the function that returns the token file path"""
+        # pylint: disable=C0301 # lambdas must be on one line
+        test = lambda expected, config, msg: self.assertEqual(expected, token._token_file_path(config), msg)
+
+        test("~/.cmr_token", None, "Not specified")
+        test("~/.cmr_token", {"env" : None}, "None value")
+        test("~/.cmr_token", {"env" : ""}, "Empty value")
+        test("~/.cmr_token", {"env" : "OPS"}, "OPS specified")
+        test("~/.cmr_token.uat", {"env" : "uat"}, "UAT specified")
+        test("~/.cmr_token.uat", {"env" : "Uat"}, "UAT, mixed case, specified")
+        test("~/.cmr_token.sit", {"env" : "sit"}, "SIT specified")
+
+        test("/tmp/token", {"env": "sit", "cmr.token.file": "/tmp/token"}, "File specified")
+
     def test_token_file_ignoring_comments(self):
         """
         Test a valid login using the password file lambda. The file itself will

--- a/CMR/python/test/cmr/auth/test_token.py
+++ b/CMR/python/test/cmr/auth/test_token.py
@@ -109,6 +109,21 @@ class TestToken(unittest.TestCase):
         #cleanup
         util.delete_file(token_file)
 
+    def test_use_bearer_token(self):
+        """Test the function that handles all the work of tokens"""
+        tokener = token.token_literal("test") #this always returns test as token
+        # pylint: disable=C0301 # lambdas must be on one line
+        tester = lambda expected, given, msg : self.assertEqual(expected, token.use_bearer_token(token_lambdas=tokener, config=given), msg)
+
+        tester({"authorization":"Bearer test"}, None, "found from none")
+        tester({"authorization":"Bearer test"}, {}, "found from nothing")
+        tester({"authorization":"Bearer test"},
+            {"authorization":"old value"},
+            "replace")
+        tester({"authorization":"Bearer test", "unrelated":"value"},
+            {"authorization":"old value", "unrelated":"value"},
+            "replace, ignoring others")
+
     # pylint: disable=W0212 ; test a private function
     def test__env_to_extention(self):
         """Check that the environment->extensions work as expected"""
@@ -120,10 +135,12 @@ class TestToken(unittest.TestCase):
         test("", {"env":None}, "Emtpy value")
         test("", {"env":""}, "Blank value")
         test("", {"env":"ops"}, "Ops specified")
+        test("", {"env":"ops."}, "Ops with a dot specified")
         test("", {"env":"prod"}, "Production specified")
         test("", {"env":"production"}, "Production specified")
         test(".uat", {"env":"uat"}, "UAT specified")
         test(".sit", {"env":"sit"}, "SIT specified")
+        test(".sit", {"env":"sit."}, "SIT with a dot specified")
         test(".future", {"env":"future"}, "Future envirnment")
 
     # pylint: disable=W0212 ; test a private function

--- a/CMR/python/test/cmr/search/test_search.py
+++ b/CMR/python/test/cmr/search/test_search.py
@@ -236,3 +236,46 @@ class TestSearch(unittest.TestCase):
             config=config)
         for i in results:
             print (i)
+
+    @patch('urllib.request.urlopen')
+    def test_logged_search(self, urlopen_mock):
+        """
+        Test that search still runs as expected when logging is turned on
+        """
+        # Setup
+        recorded_data_file = os.path.join (os.path.dirname (__file__),
+                                           '../../data/cmr/search/ten_results_from_ghrc.json')
+        urlopen_mock.return_value = valid_cmr_response(recorded_data_file)
+
+        # Test
+        with self.assertLogs(coll.scom.logger, level='DEBUG') as log_collector:
+            coll.set_logging_to("DEBUG")
+            expected = ['INFO:cmr.search.common: - POST: https://cmr.earthdata.'
+                            'nasa.gov/search/collections?page_size=1',
+                        'INFO:cmr.search.common:Total records downloaded was 10'
+                            ' of 2038 which took 10ms.']
+            coll.search({'provider':'GHRC_CLOUD'}, limit=1)
+            self.assertEqual(expected, log_collector.output)
+
+    @patch('urllib.request.urlopen')
+    def test_logged_search_with_config(self, urlopen_mock):
+        """
+        Test that search still runs as expected when logging is turned on
+        """
+        # Setup
+        recorded_data_file = os.path.join (os.path.dirname (__file__),
+                                           '../../data/cmr/search/ten_results_from_ghrc.json')
+        urlopen_mock.return_value = valid_cmr_response(recorded_data_file)
+
+        # Test
+        with self.assertLogs(coll.scom.logger, level='DEBUG') as log_collector:
+            coll.set_logging_to("DEBUG")
+            expected = ['INFO:cmr.search.common:Using a CMR-Token',
+                        'INFO:cmr.search.common:Using an Authorization token',
+                        'INFO:cmr.search.common: - POST: https://cmr.earthdata.'
+                            'nasa.gov/search/collections?page_size=1',
+                        'INFO:cmr.search.common:Total records downloaded was 10'
+                            ' of 2038 which took 10ms.']
+            config = {"cmr-token": "fake-token", "authorization": "fake-token"}
+            coll.search({'provider':'GHRC_CLOUD'}, config=config, limit=1)
+            self.assertEqual(expected, log_collector.output)

--- a/CMR/python/test/cmr/util/test_common.py
+++ b/CMR/python/test/cmr/util/test_common.py
@@ -115,9 +115,15 @@ class TestSearch(unittest.TestCase):
 
     def test_mask_string(self):
         """Test that the mask_diictionary function will clean out sensitive info"""
-        data = 'EDL-U12345678901234567890'
-        expected1 = 'EDL-U123********34567890'
-        self.assertEqual(expected1, com.mask_string(data))
+        # pylint: disable=C0301 # lambdas must be on one line
+        tester = lambda expected, given, msg : self.assertEqual(expected, com.mask_string(given), msg)
+
+        tester("", None, "None sent")
+        tester("", "", "No Letters")
+        tester("0", "0", "One letter")
+        tester("01", "01", "Two Letters")
+        tester("0*2", "012", "Three Letters")
+        tester('EDL-U123********34567890', 'EDL-U12345678901234567890', "Real example")
 
     def test_mask_dictionary(self):
         """Test that the mask_diictionary function will clean out sensitive info"""

--- a/CMR/python/test/cmr/util/test_common.py
+++ b/CMR/python/test/cmr/util/test_common.py
@@ -65,6 +65,12 @@ class TestSearch(unittest.TestCase):
         self.assertEqual((), com.always(None, otype=tuple), 'None, tuple')
         self.assertEqual((), com.always(None, tuple), 'None, tuple, positional')
 
+    def test_mask_string(self):
+        """Test that the mask_diictionary function will clean out sensitive info"""
+        data = 'EDL-U12345678901234567890'
+        expected1 = 'EDL-U123********34567890'
+        self.assertEqual(expected1, com.mask_string(data))
+
     def test_mask_dictionary(self):
         """Test that the mask_diictionary function will clean out sensitive info"""
         data = {'ignore': 'this',

--- a/CMR/python/test/cmr/util/test_common.py
+++ b/CMR/python/test/cmr/util/test_common.py
@@ -23,10 +23,12 @@ Created: 2020-10-15
 """
 
 #from unittest.mock import Mock
-#from unittest.mock import patch
+from unittest.mock import patch
 import unittest
 
-#import test.cmr as tutil
+import os
+import uuid
+
 import cmr.util.common as com
 
 # ******************************************************************************
@@ -64,6 +66,52 @@ class TestSearch(unittest.TestCase):
         self.assertEqual([], com.always(None, otype=list), 'None, list')
         self.assertEqual((), com.always(None, otype=tuple), 'None, tuple')
         self.assertEqual((), com.always(None, tuple), 'None, tuple, positional')
+
+    def test_drop_key_safely(self):
+        """Test that values can be dropped safely"""
+        # pylint: disable=C0301 # lambdas must be on one line
+        tester = lambda expected, src, key, msg : self.assertEqual(expected, com.drop_key_safely(src, key), msg)
+        tester({}, {}, "Not existing", "Empty dictionary")
+        tester({"key":"value"}, {"key": "value"}, "not found", "wrong key, no drop")
+        tester({}, {"key":"value"}, "key", "drop found key")
+
+    def test_write_read_round_trip(self):
+        """
+        Test the read and write functions by doing a full round trip test. Save
+        some text to a temp file, then read it back, testing both functions at once
+        """
+        path = "/tmp/" + str(uuid.uuid4())
+        expected = str(uuid.uuid4())
+        com.write_file(path, expected)
+        actual = com.read_file(path)
+        os.remove(path) # cleanup now
+        self.assertEqual(expected, actual, "Write-Read round trip")
+
+    def test_execute_command(self):
+        """Execute will run any command, test that it behaves as expected"""
+        # pylint: disable=C0301 # lambdas must be on one line
+        tester = lambda expected, given, msg : self.assertEqual(expected, com.execute_command(given), msg)
+        tester("", "true", "Test a single command response")
+        tester("_result_", ["printf", '_%s_', 'result'], "Test a command with properties")
+
+    @patch('cmr.util.common.execute_command')
+    def test_security_call(self, execute_command_mock):
+        """
+        test that the code will call an external command and respond as expected
+        """
+        execute_command_mock.return_value = " response info "
+        self.assertEqual("response info", com.call_security("account", "service"), "Good response")
+
+        execute_command_mock.return_value = None
+        try:
+            com.call_security("account", "service")
+        except TypeError as err:
+            self.assertEqual('account not found in keychain', str(err), "Bad response")
+
+    def test_help_format_lambda(self):
+        """Test that the lambda function performs as expected"""
+        cmd = com.help_format_lambda()
+        self.assertTrue("str(object='') -> str" in cmd("str", ""))
 
     def test_mask_string(self):
         """Test that the mask_diictionary function will clean out sensitive info"""

--- a/CMR/python/test/cmr/util/test_network.py
+++ b/CMR/python/test/cmr/util/test_network.py
@@ -87,7 +87,6 @@ class TestSearch(unittest.TestCase):
         expected = {'key1': ['v1', 'v2'], 'key2': ['v3']}
         self.assertEqual(expected, result)
 
-
     def test_config_to_header(self):
         """
         Test the helper function which converts values in the config dictionary


### PR DESCRIPTION
Adding logging and Bearer token handling code, updated examples and documentation

A reference to a related issue ticket number

Adding functions to get the token from a file and store it in a config dictionary as a Bearer token.
Added logging code to give internal details about tokens.

To test, try the code in the readme file or the token notebook.