### PR TITLE
example needed to change to show this working with github library

### DIFF
--- a/CMR/python/demos/notebooks/tokens.ipynb
+++ b/CMR/python/demos/notebooks/tokens.ipynb
@@ -49,7 +49,6 @@
    "source": [
     "import os\n",
     "import sys\n",
-    "import getpass\n",
     "sys.path.append(os.path.expanduser('~/src/project/eo-metadata-tools/CMR/python/'))"
    ]
   },
@@ -57,7 +56,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "----\n",
+    "\n",
     "### 'Import' the library into the notebook\n",
+    "**Continue with this step after you do either Choice A or B above.**\n",
+    "\n",
     "This should be all you need after we get PIP support. Take care to make sure you install to the same version of python if you have multiple instances. If any errors are shown then you may not have installed the library correctly."
    ]
   },
@@ -128,6 +131,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import getpass\n",
+    "\n",
     "# Ask the user for their name and password in the EDL SIT envirnment\n",
     "user = input('Enter in the EDL user name for SIT -> ')\n",
     "password = getpass.getpass(\"Enter in the EDL password for \" + user + \"-> \")\n",


### PR DESCRIPTION
CMR-7409

when running the compiled library, the notebook example could not be followed exactly as described. These text changes should make things more clear.