### PR TITLE
Bugfix/cmr-7820 - fixing url builder to prevent it from failing on expected requests.

### DIFF
--- a/CMR/python/cmr/search/common.py
+++ b/CMR/python/cmr/search/common.py
@@ -39,7 +39,7 @@ import logging
 import math
 import webbrowser as web
 
-import cmr.util.common as common
+from cmr.util import common
 import cmr.util.network as net
 
 # ******************************************************************************
@@ -138,6 +138,7 @@ def _cmr_query_url(base: str, query: dict, page_state: dict, config: dict = None
         config: configurations, responds to:
             * env - sit, uat, ops, prod, production, or blank for production
     """
+    #here
     if query is None:
         query = {}
     if int(page_state['limit'])>2000:
@@ -157,18 +158,20 @@ def _cmr_basic_url(base: str, query: dict, config: dict = None):
         config: configurations, responds to:
             * env - sit, uat, ops, prod, production, or blank for production
     """
-    expanded = ""
-    if query is not None and len(query)>0:
-        expanded = "?" + net.expand_query_to_parameters(query)
+    base = common.always(base, str)
 
-    config = common.always(config)
-    env = config.get('env', '').lower().strip()
-    if len(env)>0 and not env.endswith("."):
-        env += "."
-    if env in ['', 'ops', 'prod', 'production']:
-        env = ""
+    query = common.always(query)
+    query = '' if len(query)<1 else f'?{net.expand_query_to_parameters(query)}'
 
-    url = ('https://cmr.{}earthdata.nasa.gov/search/{}{}').format(env, base, expanded)
+    env = common.always(config).get('env', '')
+    if env is None:
+        env = ''
+    env = env.strip().lower()
+    if env not in ['sit', 'uat']:
+        env = ''
+
+    url = f'https://cmr.{env}.earthdata.nasa.gov/search/{base}{query}'
+    url = url.replace("r..e", "r.e")
     return url
 
 # document-it: {"key":"accept", "default":"application/vnd.nasa.cmr.umm_results+json"}

--- a/CMR/python/cmr/util/common.py
+++ b/CMR/python/cmr/util/common.py
@@ -80,6 +80,8 @@ def always(obj: dict, otype = dict):
         obj = obj if isinstance(obj, list) else []
     elif otype == tuple:
         obj = obj if isinstance(obj, tuple) else ()
+    elif otype == str:
+        obj = obj if isinstance(obj, str) else ''
     return obj
 
 def drop_key_safely(dictionary, key):
@@ -99,7 +101,7 @@ def read_file(path):
     """
     text = None
     if os.path.isfile(path):
-        with open(path, "r") as file:
+        with open(path, 'r', encoding='utf-8') as file:
             text = file.read().strip()
             file.close()
     return text
@@ -112,7 +114,7 @@ def write_file(path, text):
         text (string): content for file
     """
     path = os.path.expanduser(path)
-    with open(path, "w+") as cache:
+    with open(path, 'w+', encoding='utf-8') as cache:
         cache.write(text)
         cache.close()
 

--- a/CMR/python/cmr/util/network.py
+++ b/CMR/python/cmr/util/network.py
@@ -26,7 +26,7 @@ import logging
 import urllib.parse
 import urllib.request
 
-import cmr.util.common as common
+from cmr.util import common
 
 logging.basicConfig(level = logging.ERROR)
 logger = logging.getLogger('cmr.util.network')

--- a/CMR/python/demos/scripts/color.py
+++ b/CMR/python/demos/scripts/color.py
@@ -15,15 +15,15 @@ from enum import Enum
 class Code(Enum):
     """ Terminal codes """
     RED = "\033[0;31m"
-    GREEN ='\033[0;32m'
-    YELLOW ='\033[0;33m'
-    BLUE ='\033[0;34m'
+    GREEN ="\033[0;32m"
+    YELLOW ="\033[0;33m"
+    BLUE ="\033[0;34m"
 
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    HEADER = '\033[95m'
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    HEADER = "\033[95m"
 
     NONE = "\033[0m"
 
@@ -45,12 +45,12 @@ def yellow(msg):
 
 def style_text(msg, color):
     "returned text with terminal codes"
-    return color + msg + Code.NONE
+    return str(color.value) + msg + str(Code.NONE.value)
 
-print ("Primary Colors: %s %s %s." % (red("Red"), green("Green"), blue("Blue")))
-print ("Traffic Lights: %s %s %s." % (red("stop"), yellow("faster"), green("go")))
-print ("Test: %s, %s, %s, %s, %s." % (style_text("bold", Code.BOLD),
-    style_text("underline", Code.UNDERLINE),
-    style_text("warning", Code.WARNING),
-    style_text("fail", Code.FAIL),
-    style_text("header", Code.HEADER)))
+print (f'Primary Colors: {red("Red")} {green("Green")}  {blue("Blue")}')
+print (f'Traffic Lights: {red("stop")} {yellow("faster")} {green("go")}')
+print (f'Test: {style_text("bold", Code.BOLD)}, '
+    f'{style_text("underline", Code.UNDERLINE)}, '
+    f'{style_text("warning", Code.WARNING)}, '
+    f'{style_text("fail", Code.FAIL)}, '
+    f'{style_text("header", Code.HEADER)}')

--- a/CMR/python/demos/scripts/demo.py
+++ b/CMR/python/demos/scripts/demo.py
@@ -19,7 +19,7 @@ import cmr.search.collection as coll
 def text_color(message='{}', color_code='\033[0;37m'):
     """Set text to a color, default color is White"""
     no_color = '\033[0m'
-    return '{}{}{}'.format(color_code, message, no_color)
+    return f'{color_code}{message}{no_color}'
 
 def style_error(msg='{}'):
     """Set text to red"""
@@ -39,9 +39,9 @@ def style_input(msg='{}'):
 # Get to work
 def main():
     """The commands main method"""
-    print ("running version: {}".format(str(cmr_imp.BUILD)))
+    print (f'running version: {str(cmr_imp.BUILD)}')
     print (style_input("Enter in a free text search:"))
-    ask = input(">")
+    ask = input('>')
     params = {}
     if len(ask)>0:
         params = {'keyword': ask}
@@ -50,7 +50,7 @@ def main():
         params = {'fake-parameter': 'value for fake parameter'}
 
     #params = {'polygon': '10,10,30,10,30,20,10,20,10,10'}
-    print ('Searching for {}'.format(params))
+    print (f'Searching for {params}')
 
     coll.set_logging_to('DEBUG')
     time_start = time.time()
@@ -74,7 +74,7 @@ def main():
 
     for item in output_result:
         print (output_format.format(item))
-    print ("It took {} seconds to pull {} records.".format(durration, len(raw_results)))
+    print (f'It took {durration} seconds to pull {len(raw_results)} records.')
 
 if __name__ == '__main__':
     main()

--- a/CMR/python/demos/scripts/demo2.py
+++ b/CMR/python/demos/scripts/demo2.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
 def text_color(msg='{}', color='\033[0;37m'):
     """Defaults to White"""
     no_color = '\033[0m'
-    return '{}{}{}'.format(color, msg, no_color)
+    return f'{color}{msg}{no_color}'
 def style_error(msg='{}'):
     """Set text to red"""
     red_code = '\033[0;31m'

--- a/CMR/python/demos/scripts/scroll.py
+++ b/CMR/python/demos/scripts/scroll.py
@@ -47,7 +47,7 @@ def main():
     Test the function and verify that it is returning unique records
     """
     records = get_block_of_records({"keyword": "food"})
-    print ("returned items: {}".format(len(records)))
+    print (f'returned items: {len(records)}')
 
     processed_records = {}
     for item in records:
@@ -57,7 +57,7 @@ def main():
         short_name = umm["ShortName"]
         processed_records[cid] = short_name
 
-    print ("uniq keys: {}".format(len(processed_records.keys())))
+    print (f'uniq keys: {len(processed_records.keys())}')
 
 if __name__ == '__main__':
     main()

--- a/CMR/python/demos/scripts/vars.py
+++ b/CMR/python/demos/scripts/vars.py
@@ -17,16 +17,16 @@ def get_block_of_records(search, env=None):
     # build a url
     if env is None:
         env = 'sit' # assume SIT because that is where the data is
-    elif env in ['', 'ops', 'prod', 'production']: # production has many names
+    elif env not in ['sit', 'uat']: # production has many names
         env = '' # assume empty string which will result in '..' later
     if env == 'localhost':
         base = 'http://localhost:3003'
     else:
-        base = "https://cmr.{}.earthdata.nasa.gov/search".format(env)
+        base = f'https://cmr.{env}.earthdata.nasa.gov/search'
         base = base.replace("r..e", "r.e")
 
-    url = "{}/variables?{}".format(base, net.expand_query_to_parameters(search))
-    print("Using {} for network example.".format(url))
+    url = f'{base}/variables?{net.expand_query_to_parameters(search)}'
+    print(f'Using {url} for network example.')
 
     # setup headers and inputs
     accept = "application/vnd.nasa.cmr.umm_results+json"
@@ -46,10 +46,10 @@ def process_records(title, records):
         cid = meta["concept-id"]
         var_name = umm["Name"]
         processed_records[cid] = var_name
-    print ("\n## {} ##".format(title))
-    print ("* Returned item count: {}".format(len(records)))
-    print ("* Uniq keys: {}".format(len(processed_records.keys())))
-    print ("* {}".format(processed_records))
+    print (f'\n## {title} ##')
+    print (f'* Returned item count: {len(records)}')
+    print (f'* Uniq keys: {len(processed_records.keys())}')
+    print (f'* {processed_records}')
 
 def use_low_level_network(query, env):
     """ Make a call for variables using the lower level network code """

--- a/CMR/python/setup.py
+++ b/CMR/python/setup.py
@@ -22,5 +22,5 @@ setuptools.setup(
         "License :: Apache License 2.0",
         "Operating System :: OS Independent",
     ],
-    python_requires='>=3.4',
+    python_requires='>=3.6',
 )

--- a/CMR/python/test/cmr/__init__.py
+++ b/CMR/python/test/cmr/__init__.py
@@ -68,7 +68,7 @@ def read_file(path):
     """
     text = None
     if os.path.isfile(path):
-        with open(path, "r") as file:
+        with open(path, 'r', encoding='utf-8') as file:
             text = file.read().strip()
             file.close()
     return text

--- a/CMR/python/test/cmr/auth/test_token.py
+++ b/CMR/python/test/cmr/auth/test_token.py
@@ -31,8 +31,8 @@ from datetime import datetime
 
 import test.cmr as util
 
-import cmr.auth.token as token
-import cmr.util.common as common
+from cmr.auth import token
+from cmr.util import common
 
 # ******************************************************************************
 

--- a/CMR/python/test/cmr/search/test_granule.py
+++ b/CMR/python/test/cmr/search/test_granule.py
@@ -29,7 +29,7 @@ from functools import partial
 
 import test.cmr as tutil
 
-import cmr.util.common as common
+from cmr.util import common
 import cmr.search.granule as gran
 
 # ******************************************************************************

--- a/CMR/python/test/cmr/search/test_search.py
+++ b/CMR/python/test/cmr/search/test_search.py
@@ -27,7 +27,7 @@ import unittest
 
 import test.cmr as tutil
 
-import cmr.util.common as common
+from cmr.util import common
 import cmr.search.collection as coll
 
 # ******************************************************************************

--- a/CMR/python/test/cmr/util/test_common.py
+++ b/CMR/python/test/cmr/util/test_common.py
@@ -59,6 +59,9 @@ class TestSearch(unittest.TestCase):
         self.assertEqual(['a', 'b'], com.always(['a','b'], otype=list), 'populated list')
         self.assertEqual((1,2,3), com.always((1,2,3), otype=tuple), 'populated tuple')
         self.assertEqual((1,2,3), com.always((1,2,3), tuple), 'populated tuple, positional')
+        self.assertEqual('', com.always(None, str), 'not populated string, positional')
+        self.assertEqual('', com.always('', str), 'empty string, positional')
+        self.assertEqual('text', com.always('text', str), 'populated string, positional')
 
         # None use cases
         self.assertEqual({}, com.always(None), 'assumed, none, dict')

--- a/CMR/python/test/cmr/util/test_network.py
+++ b/CMR/python/test/cmr/util/test_network.py
@@ -30,7 +30,7 @@ import urllib.error as urlerr
 
 import test.cmr as tutil
 
-import cmr.util.common as common
+from cmr.util import common
 import cmr.util.network as net
 
 # ******************************************************************************


### PR DESCRIPTION
Ticket CMR-7820

It was possible to specify values for the env which caused the url builder function to return a bad CMR URL.

cmr/search/common, cmr/util/common.py and the related test files are the only ones related to the bug fix.

The vast majority of these file changes are pylint requested changes however to bring the code back to zero warnings.

python moved to 3.6 as this is the standard that pylint is working against.