### PR TITLE
CMR-8863: Investigate graphDb operational issues

### DIFF
--- a/CMR/python/graphql/graphqlPaging.py
+++ b/CMR/python/graphql/graphqlPaging.py
@@ -1,0 +1,59 @@
+import json
+import os
+import requests
+# Iterate over pages of graphql retrieving the search after cursor to do so
+token = os.getenv('TOKEN')
+# graphql-address e.g. 'https://graphql.sit.earthdata.nasa.gov/api'
+endpoint = os.getenv('GRAPHQL_URL')
+headers = {"Authorization": f"{token}"}
+cursor = ""
+page_num = 0
+query = """query ($params: CollectionsInput) {
+  collections(params: $params) {
+    cursor
+    items {
+      conceptId
+    }
+  }
+}"""
+
+variables = """{
+  "params":{
+    "limit":1,
+    "cursor":"%s"
+  }
+}"""% (cursor)
+
+response = requests.post(url=endpoint, json={"query": query, "variables": variables}, headers=headers)
+first_result = response.json()
+# Retrieve the first cursor value
+cursor = first_result.get('data', {}).get('collections', {}).get('cursor')
+print("Response status code: ", response.status_code)
+
+if response.status_code == 200:
+    arr = []
+    while(cursor):
+        # update variable by passing in the cursor with the updated value
+        variables = """{
+        "params":{
+            "limit":1000,
+            "cursor":"%s"
+        }
+        }"""% (cursor)
+        print('current page', page_num)
+        print('search_after cursor value', cursor)
+        response = requests.post(url=endpoint, json={"query": query, "variables": variables}, headers=headers)
+        result = response.json()
+        collections = result.get('data', {}).get('collections', {}).get('items', [])
+        cursor = result.get('data', {}).get('collections', {}).get('cursor')
+        # print("Response in json: ", collections)
+        for collection in collections:
+            arr.append(collection.get('conceptId'))
+        page_num = page_num + 1
+  
+    print('total number of pages', page_num)
+    arr.sort()
+    # Write the sorted concept-id list to a local folder
+    with open("collectionConceptIdList.txt", "w") as txt_file:
+        for collection in arr:
+            txt_file.write(f"{collection}\n")

--- a/CMR/python/graphql/graphqlPaging.py
+++ b/CMR/python/graphql/graphqlPaging.py
@@ -5,6 +5,7 @@ import requests
 token = os.getenv('TOKEN')
 # graphql-address e.g. 'https://graphql.sit.earthdata.nasa.gov/api'
 endpoint = os.getenv('GRAPHQL_URL')
+# Bearer may be needed before the token if you are using a personal token
 headers = {"Authorization": f"{token}"}
 cursor = ""
 page_num = 0

--- a/CMR/python/graphql/graphqlPaging.py
+++ b/CMR/python/graphql/graphqlPaging.py
@@ -1,11 +1,24 @@
-import json
+"""
+Iterates over cmr-graphql (https://github.com/nasa/cmr-graphql/) to
+retrieve all of the collection's concept-ids from a given env (SIT, UAT, PROD)
+a valid token must be passed
+as an env variable otherwise only what is publicly available will be able to be fetched
+then print the list of these concepts to a local file
+"""
 import os
 import requests
-# Iterate over pages of graphql retrieving the search after cursor to do so
+import sys
+import logging
+
+# Set logging
+logging.basicConfig(level=logging.DEBUG)
+
 token = os.getenv('TOKEN')
-# graphql-address e.g. 'https://graphql.sit.earthdata.nasa.gov/api'
-endpoint = os.getenv('GRAPHQL_URL')
-# Bearer may be needed before the token if you are using a personal token
+
+endpoint = os.getenv('GRAPHQL_URL', 'https://graphql.earthdata.nasa.gov/api')
+
+# Bearer may be needed before the token in your env var
+# if you are using an EDL token instead of a launchpad or echo
 headers = {"Authorization": f"{token}"}
 cursor = ""
 page_num = 0
@@ -25,14 +38,20 @@ variables = """{
   }
 }"""% (cursor)
 
-response = requests.post(url=endpoint, json={"query": query, "variables": variables}, headers=headers)
+response = requests.post(url=endpoint, json={"query": query, "variables": variables}, headers=headers, timeout=5)
 first_result = response.json()
-# Retrieve the first cursor value
-cursor = first_result.get('data', {}).get('collections', {}).get('cursor')
-print("Response status code: ", response.status_code)
 
+# Retrieve the first cursor value
+if (response.status_code == 200):
+  cursor = first_result.get('data', {}).get('collections', {}).get('cursor')
+else:
+  print("There was a failure in retrieving the first cursor check logs for status code")
+  logging.debug('Response status code:  f{response.status_code}')
+  sys.exit()
+
+# Retrieve subsequent collections
 if response.status_code == 200:
-    arr = []
+    all_collections = []
     while(cursor):
         # update variable by passing in the cursor with the updated value
         variables = """{
@@ -42,19 +61,19 @@ if response.status_code == 200:
         }
         }"""% (cursor)
         print('current page', page_num)
-        print('search_after cursor value', cursor)
-        response = requests.post(url=endpoint, json={"query": query, "variables": variables}, headers=headers)
+        logging.debug('Search_after cursor values f{cursor}')
+        response = requests.post(url=endpoint, json={"query": query, "variables": variables}, headers=headers, timeout=5)
         result = response.json()
         collections = result.get('data', {}).get('collections', {}).get('items', [])
         cursor = result.get('data', {}).get('collections', {}).get('cursor')
-        # print("Response in json: ", collections)
+        logging.debug('Response in json: f{collections}')
         for collection in collections:
-            arr.append(collection.get('conceptId'))
+            all_collections.append(collection.get('conceptId'))
         page_num = page_num + 1
   
-    print('total number of pages', page_num)
-    arr.sort()
+    print('Total number of pages f{page_num}')
+    all_collections.sort()
     # Write the sorted concept-id list to a local folder
-    with open("collectionConceptIdList.txt", "w") as txt_file:
-        for collection in arr:
+    with open("collectionConceptIdList.txt", "w", encoding='UTF-8') as txt_file:
+        for collection in all_collections:
             txt_file.write(f"{collection}\n")


### PR DESCRIPTION
* Related to ticket, insofar as it is one of the scripts used for analysis to compare the collections on CMR to those in graphDb

* Running python graphqlPaging.py will write the concept-ids of all collections that you have access to according to your TOKEN. These will be printed to a local file collectionConceptIdList.txt

* A fairly minimal example for using python to call cmr-graphql and retrieve data



