### PR TITLE
CMR-8895 - remove references to echo token

### DIFF
--- a/.github/workflows/latest.yml
+++ b/.github/workflows/latest.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Update Version Info

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install dependencies
       run: |
         python3 -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Unit Tests

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.8
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Run Unit Tests

--- a/CMR/python/cmr/search/common.py
+++ b/CMR/python/cmr/search/common.py
@@ -105,7 +105,7 @@ def _continue_download(page_state):
     items_downloaded = page_state['page_size']*page_state['page_num']
     return items_downloaded<limit
 
-# document-it: {"key":"cmr-token", "default":"None", "msg":"also known as the echo token"}
+# document-it: {"key":"Authorization", "default":"None", "msg":"also known as a cmr or EDL token"}
 # document-it: {"key":"X-Request-id", "default":"None"}
 # document-it: {"key":"Client-Id", "default":"python_cmr_lib"}
 # document-it: {"key":"User-Agent", "default":"python_cmr_lib"}
@@ -114,14 +114,15 @@ def _standard_headers_from_config(config: dict):
     Create a dictionary with the CMR specific headers meant to be passed to urllib
     Parameters:
         config (dictionary): where to pull configurations from, responds to:
-            * cmr-token: a CMR token, AKA an Echo Token, any token CMR will accept
+            * cmr-token: a CMR token, any token CMR will accept
+            * authorization: any Authorization token CMR will accept
             * X-Request-Id: Used for tracking requests across systems
             * Client-Id: Browser Agent Name
     Returns:
         dictionary with headers suitable for passing to urllib
     """
     headers = None
-    headers = net.config_to_header(config, 'cmr-token', headers, 'Echo-Token')
+    headers = net.config_to_header(config, 'cmr-token', headers, 'Authorization')
     headers = net.config_to_header(config, 'authorization', headers, 'Authorization')
     headers = net.config_to_header(config, 'X-Request-Id', headers)
     headers = net.config_to_header(config, 'Client-Id', headers, default='python_cmr_lib')
@@ -201,8 +202,6 @@ def _make_search_request(base: str, query: dict, page_state: dict, config: dict)
     # Build headers
     headers = _standard_headers_from_config(config)
 
-    if 'Echo-Token' in headers:
-        logger.info('Using a CMR-Token')
     if 'Authorization' in headers:
         logger.info('Using an Authorization token')
 

--- a/CMR/python/cmr/search/granule.py
+++ b/CMR/python/cmr/search/granule.py
@@ -76,8 +76,10 @@ def _collection_sample_limits(limits):
     """
     Assure that the limit values are not None and have reasonable values
     """
-    build = lambda gran, coll : {'granule': gran, 'collection': coll}
-    bound = lambda lower, value, upper : min(max(lower, value), upper)
+    def build (gran, coll):
+        return {'granule': gran, 'collection': coll}
+    def bound (lower, value, upper):
+        return min(max(lower, value), upper)
 
     default_granule_limit = 10
     default_collection_limit = 20
@@ -120,10 +122,9 @@ def _collection_samples(collection_query, limit, config):
     not require the loading of the search.py file, call the already loaded common
     file.
     """
-    just_cid = lambda obj : obj.get('meta', {}).get('concept-id')
     found_collections = scom.search_by_page("collections",
         query=collection_query,
-        filters=just_cid,
+        filters = lambda obj : obj.get('meta', {}).get('concept-id'),
         page_state=scom.create_page_state(limit=limit),
         config=config)
     return found_collections[:limit]

--- a/CMR/python/cmr/util/common.py
+++ b/CMR/python/cmr/util/common.py
@@ -145,8 +145,7 @@ def help_format_lambda(contains=""):
     """
     layout = "\n{}:\n{}\n"
     # n=name, c=content ; made short to keep line length down and pylint happy
-    out = lambda n, c : (layout.format(n, c.__doc__.strip())) if contains in n else ""
-    return out
+    return lambda n, c : (layout.format(n, c.__doc__.strip())) if contains in n else ""
 
 def mask_string(unsafe_value):
     """Prevent sensitive information from being printed by masking values """

--- a/CMR/python/demos/scripts/edl_token.py
+++ b/CMR/python/demos/scripts/edl_token.py
@@ -1,0 +1,38 @@
+"""
+A very short script showing how to use a file defined token from EDL. Pass in
+the path to the file containing nothing but the EDL token as the first and only
+parameter to the script. This will be read by the token library and included in
+the config dictionary.
+"""
+
+import sys
+
+import cmr.search.collection as coll
+import cmr.auth.token as t
+
+########################################
+# Basic inputs for search
+params = {'keyword': 'fish food'}
+configurations={'env':'sit'}
+
+########################################
+# Basic search with no token
+public_count = len(coll.search(params, limit=500, config=configurations))
+print (f"Records when not logged in: {public_count}")
+
+########################################
+# Add token to config
+if len(sys.argv)>1:
+    configurations['cmr.token.file'] = '~/.pw/urs.token.sit'
+    print ("\nUsing a token from user specificed file...")
+configurations = t.use_bearer_token(config=configurations)
+
+########################################
+# Basic search, now WITH a token
+private_count = len(coll.search(params, limit=500, config=configurations))
+print (f"Records when logged in: {private_count}")
+
+########################################
+# Conclusion
+if public_count != private_count:
+    print ("\nLogging in results in a different number of records.")

--- a/CMR/python/demos/scripts/edl_token.py
+++ b/CMR/python/demos/scripts/edl_token.py
@@ -18,21 +18,21 @@ configurations={'env':'sit'}
 ########################################
 # Basic search with no token
 public_count = len(coll.search(params, limit=500, config=configurations))
-print (f"Records when not logged in: {public_count}")
+print (f'Records when not logged in: {public_count}')
 
 ########################################
 # Add token to config
-if len(sys.argv)>1:
-    configurations['cmr.token.file'] = '~/.pw/urs.token.sit'
-    print ("\nUsing a token from user specificed file...")
+if len(sys.argv)>1 and len(sys.argv[1])>0:
+    configurations['cmr.token.file'] = sys.argv[1]
+    print ('\nUsing a token from user specificed file...')
 configurations = t.use_bearer_token(config=configurations)
 
 ########################################
 # Basic search, now WITH a token
 private_count = len(coll.search(params, limit=500, config=configurations))
-print (f"Records when logged in: {private_count}")
+print (f'Records when logged in: {private_count}')
 
 ########################################
 # Conclusion
 if public_count != private_count:
-    print ("\nLogging in results in a different number of records.")
+    print ('\nLogging in results in a different number of records.')

--- a/CMR/python/demos/scripts/providers.py
+++ b/CMR/python/demos/scripts/providers.py
@@ -4,7 +4,6 @@ A very short demo of how to use the provider API
 
 import cmr.search.providers as p
 
-
 print(p.search_by_id(None))
 
 print ("*"*80)

--- a/CMR/python/demos/scripts/providers.py
+++ b/CMR/python/demos/scripts/providers.py
@@ -1,0 +1,27 @@
+"""
+A very short demo of how to use the provider API
+"""
+
+import cmr.search.providers as p
+
+
+print(p.search_by_id(None))
+
+print ("*"*80)
+print(p.search_by_id(''))
+
+print ("*"*80)
+print(p.search_by_id('.*GHRC.*'))
+
+print ("*"*80)
+print(p.search_by_id('*GHRC*'))
+
+print ("*"*80)
+print(p.search_by_id('.*GHRC.*', {'env':'uat'}))
+
+print ("*"*80)
+result = p.search_by_id('.*GHRC.*', {'env':'uat'})
+if 'errors' in result:
+    print('found errors')
+else:
+    print (len(result))

--- a/CMR/python/demos/scripts/providers.py
+++ b/CMR/python/demos/scripts/providers.py
@@ -2,23 +2,28 @@
 A very short demo of how to use the provider API
 """
 
+from functools import partial
+
 import cmr.search.providers as p
+
+# be like clojure, calculate text once
+print_line = partial(print, "*" * 80)
 
 print(p.search_by_id(None))
 
-print ("*"*80)
+print_line()
 print(p.search_by_id(''))
 
-print ("*"*80)
+print_line()
 print(p.search_by_id('.*GHRC.*'))
 
-print ("*"*80)
+print_line()
 print(p.search_by_id('*GHRC*'))
 
-print ("*"*80)
+print_line()
 print(p.search_by_id('.*GHRC.*', {'env':'uat'}))
 
-print ("*"*80)
+print_line()
 result = p.search_by_id('.*GHRC.*', {'env':'uat'})
 if 'errors' in result:
     print('found errors')

--- a/CMR/python/doc/cmr.md
+++ b/CMR/python/doc/cmr.md
@@ -4,14 +4,16 @@
 * [cmr.util](#cmr.util)
 * [cmr.util.common](#cmr.util.common)
 * [cmr.util.network](#cmr.util.network)
-* [cmr.auth](#cmr.auth)
 * [cmr.auth.token](#cmr.auth.token)
+* [cmr.auth](#cmr.auth)
 * [cmr.search](#cmr.search)
 * [cmr.search.granule](#cmr.search.granule)
+* [cmr.search.providers](#cmr.search.providers)
 * [cmr.search.common](#cmr.search.common)
 * [cmr.search.collection](#cmr.search.collection)
 
-<a name="cmr"></a>
+<a id="cmr"></a>
+
 # cmr
 
 A Library interfacing with the CMR API
@@ -24,30 +26,35 @@ Create version info Query the BUILD constant for information on the package vers
 More information can be found at:
 https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html
 
-<a name="cmr.__version__"></a>
+<a id="cmr.__version__"></a>
+
 #### \_\_version\_\_
 
 Package Version number
 
-<a name="cmr.BUILD"></a>
+<a id="cmr.BUILD"></a>
+
 #### BUILD
 
 Build and version information for the entire package
 
-<a name="cmr.util"></a>
+<a id="cmr.util"></a>
+
 # cmr.util
 
-<a name="cmr.util.common"></a>
+<a id="cmr.util.common"></a>
+
 # cmr.util.common
 
 date 2020-10-26
 since 0.0
 
-<a name="cmr.util.common.conj"></a>
+<a id="cmr.util.common.conj"></a>
+
 #### conj
 
 ```python
-conj(coll, to_add)
+def conj(coll, to_add)
 ```
 
 Similar to clojure's function, add items to a list or dictionary
@@ -70,20 +77,42 @@ concrete type. if coll is:
 
   object of the same type as coll but with to_add items added
 
-<a name="cmr.util.common.drop_key_safely"></a>
+<a id="cmr.util.common.always"></a>
+
+#### always
+
+```python
+def always(obj: dict, otype=dict)
+```
+
+Ensure that something is always returned. Assumes dictionary, but list or
+tuple can be specified, because source may be none, it can not be derived
+
+**Arguments**:
+
+- `obj` - a dictionary, list, or tuple
+- `otype` - object type, the actual type `dict` (default), `list`, or `tuple`
+
+**Returns**:
+
+  {}, [], or () as needed, or the object that was passed in if it already exists
+
+<a id="cmr.util.common.drop_key_safely"></a>
+
 #### drop\_key\_safely
 
 ```python
-drop_key_safely(dictionary, key)
+def drop_key_safely(dictionary, key)
 ```
 
 Drop a key from a dict if it exists and return that change
 
-<a name="cmr.util.common.read_file"></a>
+<a id="cmr.util.common.read_file"></a>
+
 #### read\_file
 
 ```python
-read_file(path)
+def read_file(path)
 ```
 
 Read and return the contents of a file
@@ -96,11 +125,12 @@ Read and return the contents of a file
 
   None if file was not found, contents otherwise
 
-<a name="cmr.util.common.write_file"></a>
+<a id="cmr.util.common.write_file"></a>
+
 #### write\_file
 
 ```python
-write_file(path, text)
+def write_file(path, text)
 ```
 
 Write (creating if need be) file and set it's content
@@ -110,11 +140,12 @@ Write (creating if need be) file and set it's content
 - `path` _string_ - path to file to write
 - `text` _string_ - content for file
 
-<a name="cmr.util.common.execute_command"></a>
+<a id="cmr.util.common.execute_command"></a>
+
 #### execute\_command
 
 ```python
-execute_command(cmd)
+def execute_command(cmd)
 ```
 
 A utility method to execute a shell command and return a string of the output
@@ -127,80 +158,122 @@ A utility method to execute a shell command and return a string of the output
 
   response from command
 
-<a name="cmr.util.common.call_security"></a>
+<a id="cmr.util.common.call_security"></a>
+
 #### call\_security
 
 ```python
-call_security(account, service, app="/usr/bin/security")
+def call_security(account, service, app="/usr/bin/security")
 ```
 
 Call the security command to look up encrypted values
 
-<a name="cmr.util.common.help_format_lambda"></a>
+<a id="cmr.util.common.help_format_lambda"></a>
+
 #### help\_format\_lambda
 
 ```python
-help_format_lambda(contains="")
+def help_format_lambda(contains="")
 ```
 
 Return a lambda to be used to format help output for a function
 
-<a name="cmr.util.network"></a>
+<a id="cmr.util.common.mask_string"></a>
+
+#### mask\_string
+
+```python
+def mask_string(unsafe_value)
+```
+
+Prevent sensitive information from being printed by masking values
+
+<a id="cmr.util.common.mask_dictionary"></a>
+
+#### mask\_dictionary
+
+```python
+def mask_dictionary(data, keys)
+```
+
+Prevent sensitive information from being printed by masking values of listed
+keys in a dictionaries. The middle third of the values will be replaced with
+'*'. Uses Dictionaries copy() function.
+Return a shallow copy of the data dictionary that has been updated
+
+<a id="cmr.util.common.now"></a>
+
+#### now
+
+```python
+def now()
+```
+
+return the current time in a function that can be patched away for testing
+
+<a id="cmr.util.network"></a>
+
 # cmr.util.network
 
 date 2020-11-05
 since 0.0
 
-<a name="cmr.util.network.get_local_ip"></a>
+<a id="cmr.util.network.get_local_ip"></a>
+
 #### get\_local\_ip
 
 ```python
-get_local_ip()
+def get_local_ip()
 ```
 
 Rewrite this stub, it is used in code not checked in yet
 
-<a name="cmr.util.network.value_to_param"></a>
+<a id="cmr.util.network.value_to_param"></a>
+
 #### value\_to\_param
 
 ```python
-value_to_param(key, value)
+def value_to_param(key, value)
 ```
 
 Convert a key value pair into a URL parameter pair
 
-<a name="cmr.util.network.expand_parameter_to_parameters"></a>
+<a id="cmr.util.network.expand_parameter_to_parameters"></a>
+
 #### expand\_parameter\_to\_parameters
 
 ```python
-expand_parameter_to_parameters(key, parameter)
+def expand_parameter_to_parameters(key, parameter)
 ```
 
 Convert a list of values into a list of URL parameters
 
-<a name="cmr.util.network.expand_query_to_parameters"></a>
+<a id="cmr.util.network.expand_query_to_parameters"></a>
+
 #### expand\_query\_to\_parameters
 
 ```python
-expand_query_to_parameters(query=None)
+def expand_query_to_parameters(query=None)
 ```
 
 Convert a dictionary to URL parameters
 
-<a name="cmr.util.network.apply_headers_to_request"></a>
+<a id="cmr.util.network.apply_headers_to_request"></a>
+
 #### apply\_headers\_to\_request
 
 ```python
-apply_headers_to_request(req, headers)
+def apply_headers_to_request(req, headers)
 ```
 
 Apply a headers to a urllib request object
 
-<a name="cmr.util.network.transform_results"></a>
+<a id="cmr.util.network.transform_results"></a>
+
 #### transform\_results
 
 ```python
-transform_results(results, keys_of_interest)
+def transform_results(results, keys_of_interest)
 ```
 
 Take a list of results and convert them to a multi valued dictionary. The
@@ -210,11 +283,16 @@ them to a granule search.
 [{key1:value1},{key1:value2},...] -> {"key1": [value1,value2]} ->
     &key1=value1&key1=value2 ( via expand_query_to_parameters() )
 
-<a name="cmr.util.network.config_to_header"></a>
+<a id="cmr.util.network.config_to_header"></a>
+
 #### config\_to\_header
 
 ```python
-config_to_header(config, source_key, headers, destination_key=None, default=None)
+def config_to_header(config,
+                     source_key,
+                     headers,
+                     destination_key=None,
+                     default=None)
 ```
 
 Copy a value in the config into a header dictionary for use by urllib. Written
@@ -230,11 +308,12 @@ config[key] -> [or default] -> [rename] -> headers[key]
 - `destination_key(string)` - name of key to save to in headers
 - `default(string)` - value to use if value can not be found in config
 
-<a name="cmr.util.network.post"></a>
+<a id="cmr.util.network.post"></a>
+
 #### post
 
 ```python
-post(url, body, accept=None, headers=None)
+def post(url, body, accept=None, headers=None)
 ```
 
 Make a basic HTTP call to CMR using the POST action
@@ -247,10 +326,26 @@ Make a basic HTTP call to CMR using the POST action
 - `client_id` _string_ - name of the client making the (not python or curl)
 - `headers` _dictionary_ - HTTP headers to apply
 
-<a name="cmr.auth"></a>
-# cmr.auth
+<a id="cmr.util.network.get"></a>
 
-<a name="cmr.auth.token"></a>
+#### get
+
+```python
+def get(url, accept=None, headers=None)
+```
+
+Make a basic HTTP call to CMR using the POST action
+
+**Arguments**:
+
+- `url` _string_ - resource to get
+- `body` _dictionary_ - parameters to send, or string if raw text to be sent
+- `accept` _string_ - encoding of the returned data, some form of json is expected
+- `client_id` _string_ - name of the client making the (not python or curl)
+- `headers` _dictionary_ - HTTP headers to apply
+
+<a id="cmr.auth.token"></a>
+
 # cmr.auth.token
 
 A Library for managing EDL tokens to be used with CMR
@@ -258,17 +353,22 @@ date: 2020-10-26
 since: 0.0
 
 Overview:
+    The function fetch_bearer_token_with_password(user, password, config) will
+    handle all network calls to either get or generate a user token and place
+    this token inside a config dictionary for use in all other calls.
+
     The function token(lambda_list, config) will iterate over a list of token
     managers and return the value from the first manager that finds a token.
 
     Token Managers are lambda functions that take in a 'config' dictionary for
     use as a source for configurations, and returns a token as a string.
 
-<a name="cmr.auth.token.token_literal"></a>
+<a id="cmr.auth.token.token_literal"></a>
+
 #### token\_literal
 
 ```python
-token_literal(token_text: str)
+def token_literal(token_text: str)
 ```
 
 Generates an token lambda file which always returns the same value, this is
@@ -282,11 +382,12 @@ used for testing, and also as an example of how to write token managers
 
   A lambda function which takes a dictionary and returns a token
 
-<a name="cmr.auth.token.token_config"></a>
+<a id="cmr.auth.token.token_config"></a>
+
 #### token\_config
 
 ```python
-token_config(config: dict = None) -> str
+def token_config(config: dict = None)
 ```
 
 Pull a token from the configuration dictionary
@@ -296,11 +397,12 @@ Pull a token from the configuration dictionary
 - `config` - Responds to:
 - `"cmr.token.value"` - value of token, defaults to 'None'
 
-<a name="cmr.auth.token.token_file"></a>
+<a id="cmr.auth.token.token_file"></a>
+
 #### token\_file
 
 ```python
-token_file(config: dict = None) -> str
+def token_file(config: dict = None)
 ```
 
 Load a token from a local user file assumed to be ~/.cmr_token
@@ -309,14 +411,18 @@ Load a token from a local user file assumed to be ~/.cmr_token
 
 - `config` - Responds to:
 - `"cmr.token.file"` - location of token file, defaults to ~/.cmr_token
+  for production, followed by a dot and the environment name if
+  specified.
+- `"env"` - if not production, appended to the end of ~/.cmr_token with a dot
   Returns
   token from file
 
-<a name="cmr.auth.token.token_manager"></a>
+<a id="cmr.auth.token.token_manager"></a>
+
 #### token\_manager
 
 ```python
-token_manager(config: dict = None) -> str
+def token_manager(config: dict = None)
 ```
 
 Use a system like the MacOS X Keychain app. Any os which also has the
@@ -333,14 +439,187 @@ security app would also work.
 
   token from Keychain
 
-<a name="cmr.auth.token.token"></a>
+<a id="cmr.auth.token.read_tokens"></a>
+
+#### read\_tokens
+
+```python
+def read_tokens(edl_user, token_lambdas=None, config: dict = None)
+```
+
+Read and return the EDL tokens for a given user. Using this function makes
+the assumption that your storing the EDL password in one of the token lambda
+handlers and not tokens themself. This can be overwritten in the config file
+if you plan to store both tokens and password.
+
+**Arguments**:
+
+- `edl_user` - EDL User name
+- `token_lambda` - a token lambda or a list of functions
+- `config` - config dictionary to base new dictionary off of
+
+**Returns**:
+
+  a dictionary like the following:
+- `{"hits"` - 1,
+- `"items"` - [{"access_token": "EDL-UToken-Content",
+- `"expiration_date"` - "10/31/2121"}]}
+
+<a id="cmr.auth.token.create_token"></a>
+
+#### create\_token
+
+```python
+def create_token(edl_user, token_lambdas=None, config: dict = None)
+```
+
+Create and return a EDL token for a given user. Using this function makes
+the assumption that your storing the EDL password in one of the token lambda
+handlers and not tokens themself. This can be overwritten in the config file
+if you plan to store both tokens and password.
+
+**Arguments**:
+
+- `edl_user` - EDL User name
+- `token_lambda` - a token lambda or a list of functions
+- `config` - config dictionary to base new dictionary off of
+
+**Returns**:
+
+  a dictionary like the following:
+- `{"access_token"` - "EDL-UToken-Content",
+  "token_type":"Bearer",
+- `"expiration_date"` - "10/31/2121"}
+
+<a id="cmr.auth.token.delete_token"></a>
+
+#### delete\_token
+
+```python
+def delete_token(access_token,
+                 edl_user,
+                 token_lambdas=None,
+                 config: dict = None)
+```
+
+Delete a taken from EDL
+Return None if failed, otherwise EDL response
+
+<a id="cmr.auth.token.fetch_token"></a>
+
+#### fetch\_token
+
+```python
+def fetch_token(edl_user, token_lambdas=None, config: dict = None)
+```
+
+Talk to EDL and pull out a token for use in CMR calls. To lookup tokens, an
+EDL User name and password will be sent over the network.
+Return: None or Access token
+
+<a id="cmr.auth.token.fetch_bearer_token_with_password"></a>
+
+#### fetch\_bearer\_token\_with\_password
+
+```python
+def fetch_bearer_token_with_password(edl_user,
+                                     edl_password,
+                                     config: dict = None)
+```
+
+This function is the fastest way to use this API, this call will run all
+other functions needed to either get or generate a token on the users behalf.
+
+**Arguments**:
+
+- `edl_user` - user name in the Earth Data Login System
+- `edl_password` - password in the Earth Data Login system
+- `config` - configuration dictionary
+
+**Returns**:
+
+- `Success` - config dict with 'authorization' key added
+- `Error` - {'error': 'invalid_credentials', 'error_description':
+  'Invalid user credentials', 'code': 401, 'reason': 'Unauthorized'}
+
+<a id="cmr.auth.token.fetch_bearer_token"></a>
+
+#### fetch\_bearer\_token
+
+```python
+def fetch_bearer_token(edl_user, token_lambdas=None, config: dict = None)
+```
+
+This function is the similar to fetch_bearer_token_with_password() but takes
+lambda lookup functions instead of a fixed password. This call will run all
+other functions needed to either get or generate a token on the users behalf.
+
+**Arguments**:
+
+- `edl_user` - user name in the Earth Data Login System
+- `token_lambda` - a token lambda or a list of functions
+- `config` - configuration dictionary
+
+**Returns**:
+
+- `Success` - config dict with 'authorization' key added
+- `Error` - {'error': 'invalid_credentials', 'error_description':
+  'Invalid user credentials', 'code': 401, 'reason': 'Unauthorized'}
+
+<a id="cmr.auth.token.use_bearer_token"></a>
+
+#### use\_bearer\_token
+
+```python
+def use_bearer_token(token_lambdas=None, config: dict = None)
+```
+
+Create a new config dictionary, optionally based on a supplied one, and add
+the bearer token to the config object abstracting away as many details as
+possible.
+
+**Arguments**:
+
+- `token_lambda` - a token lambda or a list of functions
+- `config` - config dictionary to base new dictionary off of
+
+**Returns**:
+
+  new config dictionary with Bearer token assigned as an 'authorization'
+
+<a id="cmr.auth.token.bearer"></a>
+
+#### bearer
+
+```python
+def bearer(token_lambdas=None, config: dict = None)
+```
+
+Loops through the list of lambdas till a token is found. These lamdba functions
+return an EDL token which can be passed to Earthdata software to authenticate
+the user. To get a token, go to https://sit.urs.earthdata.nasa.gov/user_tokens
+Token is returned as a Bearer String
+
+**Arguments**:
+
+- `token_lambda` - a token lambda or a list of functions
+- `config` - Responds to no values
+
+**Returns**:
+
+  the EDL Bearer Token from the token lambda
+
+<a id="cmr.auth.token.token"></a>
+
 #### token
 
 ```python
-token(token_lambdas=None, config: dict = None) -> str
+def token(token_lambdas=None, config: dict = None)
 ```
 
-Recursively calls lambdas till a token is found
+Loops through the list of lambdas till a token is found. These lamdba functions
+return an EDL token which can be passed to Earthdata software to authenticate
+the user. To get a token, go to https://sit.urs.earthdata.nasa.gov/user_tokens
 
 **Arguments**:
 
@@ -351,11 +630,12 @@ Recursively calls lambdas till a token is found
 
   the EDL Token from the token lambda
 
-<a name="cmr.auth.token.help_text"></a>
+<a id="cmr.auth.token.help_text"></a>
+
 #### help\_text
 
 ```python
-help_text(prefix: str = '') -> str
+def help_text(prefix: str = '') -> str
 ```
 
 Built in help - prints out the public function names for the token API
@@ -368,10 +648,16 @@ Built in help - prints out the public function names for the token API
 
   text ready to be passed to print()
 
-<a name="cmr.search"></a>
+<a id="cmr.auth"></a>
+
+# cmr.auth
+
+<a id="cmr.search"></a>
+
 # cmr.search
 
-<a name="cmr.search.granule"></a>
+<a id="cmr.search.granule"></a>
+
 # cmr.search.granule
 
 A Library for building and requesting CMR granule searches
@@ -390,66 +676,73 @@ This function can handle any query parameter which is supported by the CMR.
 More information can be found at:
 https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html
 
-<a name="cmr.search.granule.all_fields"></a>
+<a id="cmr.search.granule.all_fields"></a>
+
 #### all\_fields
 
 ```python
-all_fields(item)
+def all_fields(item)
 ```
 
 Makes no change to the item, passes through. Used primarily as an example
 and for testing the filter workflow
 
-<a name="cmr.search.granule.meta_fields"></a>
+<a id="cmr.search.granule.meta_fields"></a>
+
 #### meta\_fields
 
 ```python
-meta_fields(item)
+def meta_fields(item)
 ```
 
 Return only the the meta objects
 
-<a name="cmr.search.granule.umm_fields"></a>
+<a id="cmr.search.granule.umm_fields"></a>
+
 #### umm\_fields
 
 ```python
-umm_fields(item)
+def umm_fields(item)
 ```
 
 Return only the UMM part of the data
 
-<a name="cmr.search.granule.concept_id_fields"></a>
+<a id="cmr.search.granule.concept_id_fields"></a>
+
 #### concept\_id\_fields
 
 ```python
-concept_id_fields(item)
+def concept_id_fields(item)
 ```
 
 Extract only fields that are used to identify a record
 
-<a name="cmr.search.granule.drop_fields"></a>
+<a id="cmr.search.granule.drop_fields"></a>
+
 #### drop\_fields
 
 ```python
-drop_fields(key)
+def drop_fields(key)
 ```
 
 Drop a key from a dictionary
 
-<a name="cmr.search.granule.granule_core_fields"></a>
+<a id="cmr.search.granule.granule_core_fields"></a>
+
 #### granule\_core\_fields
 
 ```python
-granule_core_fields(item)
+def granule_core_fields(item)
 ```
 
 Extract only fields that are used to identify a record
 
-<a name="cmr.search.granule.apply_filters"></a>
+<a id="cmr.search.granule.apply_filters"></a>
+
 #### apply\_filters
 
 ```python
-apply_filters(filters, items)
+def apply_filters(filters, items)
 ```
 
 Apply all the filters on the downloaded data
@@ -463,11 +756,12 @@ Apply all the filters on the downloaded data
 
   Filtered data
 
-<a name="cmr.search.granule.search"></a>
+<a id="cmr.search.granule.search"></a>
+
 #### search
 
 ```python
-search(query, filters=None, limit=None, config: dict = None)
+def search(query, filters=None, limit=None, config: dict = None)
 ```
 
 Search and return all records
@@ -483,11 +777,40 @@ Search and return all records
 
   JSON results from CMR
 
-<a name="cmr.search.granule.experimental_search_generator"></a>
+<a id="cmr.search.granule.sample_by_collections"></a>
+
+#### sample\_by\_collections
+
+```python
+def sample_by_collections(collection_query,
+                          filters=None,
+                          limits=None,
+                          config: dict = None)
+```
+
+Perform a compound search looking for granules based on the results of a
+collection search. First find a list of collections using a supplied collection
+query, then take the resulting collection IDs and perform a granule search
+with them. Granule samples are then returned from many of the collections.
+
+**Arguments**:
+
+  collection_query(dictionary) : a collection query
+- `filters(list)` - a list of filter lambdas which taken in a row and return and row
+- `limits` - an int, a list of 0 to 2 int values, or a dictionary, None values will be asasumed
+- `list` - [granule limit, collection limit]
+- `dictionary` - {'granule': None, 'collection': None}
+- `config` _dictionary_ - configuration settings
+
+<a id="cmr.search.granule.experimental_search_generator"></a>
+
 #### experimental\_search\_generator
 
 ```python
-experimental_search_generator(query, filters=None, limit=None, config: dict = None)
+def experimental_search_generator(query,
+                                  filters=None,
+                                  limit=None,
+                                  config: dict = None)
 ```
 
 WARNING: This is an experimental function, do not use in an operational
@@ -508,11 +831,12 @@ but some experimenting is needed.
 
   JSON results from CMR
 
-<a name="cmr.search.granule.open_api"></a>
+<a id="cmr.search.granule.open_api"></a>
+
 #### open\_api
 
 ```python
-open_api(section='#granule-search-by-parameters')
+def open_api(section='#granule-search-by-parameters')
 ```
 
 Ask python to open up the API in a new browser window
@@ -521,11 +845,12 @@ Ask python to open up the API in a new browser window
 
 - `selection(string)` - HTML Anchor Tag, default is `granule`-search-by-parameters
 
-<a name="cmr.search.granule.set_logging_to"></a>
+<a id="cmr.search.granule.set_logging_to"></a>
+
 #### set\_logging\_to
 
 ```python
-set_logging_to(level)
+def set_logging_to(level)
 ```
 
 Set the logging level to the stated value. Any of the standard logging level
@@ -536,16 +861,106 @@ can be used here. These include: DEBUG, INFO, WARNING, ERROR, and CRITICAL
 
 - `level` - a value like logging.INFO
 
-<a name="cmr.search.granule.help_text"></a>
+<a id="cmr.search.granule.help_text"></a>
+
 #### help\_text
 
 ```python
-help_text(contains: str = "")
+def help_text(contains: str = "")
 ```
 
 Return help for the public functions in the Granule api
 
-<a name="cmr.search.common"></a>
+<a id="cmr.search.providers"></a>
+
+# cmr.search.providers
+
+A Library for requesting CMR Provider Names
+date: 2022-03-09
+since: 0.1
+
+A provider search for CMR. Use the search() function to lookup all the providers.
+search_by_id() can be used to return only providers matching a regular expression.
+
+<a id="cmr.search.providers.search"></a>
+
+#### search
+
+```python
+def search(config: dict = None)
+```
+
+Search for and return providers, optional filter them
+
+**Arguments**:
+
+  config - configurations
+
+**Returns**:
+
+  JSON list of providers on success, Map with 'errors' otherwise
+
+<a id="cmr.search.providers.search_by_id"></a>
+
+#### search\_by\_id
+
+```python
+def search_by_id(query: str, config: dict = None)
+```
+
+Search for providers and filter them down with a Regular expression
+
+**Arguments**:
+
+- `filter` - RegExp string to match provider names
+- `config` - configurations
+
+**Returns**:
+
+  JSON list of providers on success, Map with 'errors' otherwise
+
+<a id="cmr.search.providers.set_logging_to"></a>
+
+#### set\_logging\_to
+
+```python
+def set_logging_to(level)
+```
+
+Set the logging level to the stated value. Any of the standard logging level
+as stated in https://docs.python.org/3/howto/logging.html#when-to-use-logging
+can be used here. These include: DEBUG, INFO, WARNING, ERROR, and CRITICAL
+
+**Arguments**:
+
+- `level` - a value like logging.INFO
+
+<a id="cmr.search.providers.open_api"></a>
+
+#### open\_api
+
+```python
+def open_api(section='#collection-search-by-parameters')
+```
+
+Ask python to open up the API in a new browser window
+
+<a id="cmr.search.providers.help_text"></a>
+
+#### help\_text
+
+```python
+def help_text(contains: str = "")
+```
+
+Built in help - prints out the public function names for the collection object for the token API
+
+**Arguments**:
+
+- `filter(string)` - filters out functions beginning with this text, defaults to all
+
+<a id="cmr.search.common"></a>
+
 # cmr.search.common
 
 Code common to both collection.py and granule.py
@@ -565,57 +980,86 @@ This function can handle any query parameter which is supported by the CMR.
 More information can be found at:
 https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html
 
-<a name="cmr.search.common.all_fields"></a>
+<a id="cmr.search.common.all_fields"></a>
+
 #### all\_fields
 
 ```python
-all_fields(item)
+def all_fields(item)
 ```
 
 Makes no change to the item, passes through. Used primarily as an example
 and for testing the filter workflow
 
-<a name="cmr.search.common.meta_fields"></a>
+<a id="cmr.search.common.meta_fields"></a>
+
 #### meta\_fields
 
 ```python
-meta_fields(item)
+def meta_fields(item)
 ```
 
 Return only the the meta objects
 
-<a name="cmr.search.common.umm_fields"></a>
+<a id="cmr.search.common.umm_fields"></a>
+
 #### umm\_fields
 
 ```python
-umm_fields(item)
+def umm_fields(item)
 ```
 
 Return only the UMM part of the data
 
-<a name="cmr.search.common.concept_id_fields"></a>
+<a id="cmr.search.common.concept_id_fields"></a>
+
 #### concept\_id\_fields
 
 ```python
-concept_id_fields(item)
+def concept_id_fields(item)
 ```
 
 Extract only fields that are used to identify a record
 
-<a name="cmr.search.common.drop_fields"></a>
+<a id="cmr.search.common.drop_fields"></a>
+
 #### drop\_fields
 
 ```python
-drop_fields(key)
+def drop_fields(key)
 ```
 
 Drop a key from a dictionary
 
-<a name="cmr.search.common.create_page_state"></a>
+<a id="cmr.search.common.cmr_basic_url"></a>
+
+#### cmr\_basic\_url
+
+```python
+def cmr_basic_url(base: str,
+                  query: dict = None,
+                  config: dict = None,
+                  endpoint: str = None)
+```
+
+Create a url for calling any CMR search end point, should not make any
+assumption, beyond the search directory. Will auto set the environment based
+on how config is set
+
+**Arguments**:
+
+- `base` - API base action within the endpoint
+- `query` - dictionary url parameters
+- `config` - configurations, responds to:
+  * env - sit, uat, ops, prod, production, or blank for production
+- `endpoint` - CMR endpoint/application, like search or ingest
+
+<a id="cmr.search.common.create_page_state"></a>
+
 #### create\_page\_state
 
 ```python
-create_page_state(page_size=10, page_num=1, took=0, limit=10)
+def create_page_state(page_size=10, page_num=1, took=0, limit=10)
 ```
 
 Dictionary to hold page state for the recursive call
@@ -627,11 +1071,12 @@ Dictionary to hold page state for the recursive call
 - `took` - positive number, seconds of total processing
 - `limit` - max records to return, 1-100000, default to 10
 
-<a name="cmr.search.common.clear_scroll"></a>
+<a id="cmr.search.common.clear_scroll"></a>
+
 #### clear\_scroll
 
 ```python
-clear_scroll(scroll_id, config: dict = None)
+def clear_scroll(scroll_id, config: dict = None)
 ```
 
 This action is called to clear a scroll ID from CMR allowing CMR to free up
@@ -653,11 +1098,12 @@ API call returns HTTP status code 204 when successful.
 
   error dictionary if there was a problem, otherwise a JSON object of response headers
 
-<a name="cmr.search.common.apply_filters"></a>
+<a id="cmr.search.common.apply_filters"></a>
+
 #### apply\_filters
 
 ```python
-apply_filters(filters, items)
+def apply_filters(filters, items)
 ```
 
 Apply all filters to the collection of data, returning the results
@@ -671,11 +1117,16 @@ Apply all filters to the collection of data, returning the results
 
   the results of the filters
 
-<a name="cmr.search.common.search_by_page"></a>
+<a id="cmr.search.common.search_by_page"></a>
+
 #### search\_by\_page
 
 ```python
-search_by_page(base, query=None, filters=None, page_state=None, config: dict = None)
+def search_by_page(base,
+                   query=None,
+                   filters=None,
+                   page_state=None,
+                   config: dict = None)
 ```
 
 Recursive function to download all the pages of data. Note, this function
@@ -692,11 +1143,16 @@ returning what was found in that amount of time.
   * max-time - total processing time allowed for all calls
   return collected items
 
-<a name="cmr.search.common.experimental_search_by_page_generator"></a>
+<a id="cmr.search.common.experimental_search_by_page_generator"></a>
+
 #### experimental\_search\_by\_page\_generator
 
 ```python
-experimental_search_by_page_generator(base, query=None, filters=None, page_state=None, config: dict = None)
+def experimental_search_by_page_generator(base,
+                                          query=None,
+                                          filters=None,
+                                          page_state=None,
+                                          config: dict = None)
 ```
 
 WARNING: This is an experimental function, do not use in an operational
@@ -705,20 +1161,22 @@ system, this function will go away.
 This function performs searches and returns data as a list generator. Errors
 will go mostly to logs.
 
-<a name="cmr.search.common.open_api"></a>
+<a id="cmr.search.common.open_api"></a>
+
 #### open\_api
 
 ```python
-open_api(section)
+def open_api(section)
 ```
 
 Ask python to open up the API in a new browser window - unsupported!
 
-<a name="cmr.search.common.set_logging_to"></a>
+<a id="cmr.search.common.set_logging_to"></a>
+
 #### set\_logging\_to
 
 ```python
-set_logging_to(level=logging.ERROR)
+def set_logging_to(level=logging.ERROR)
 ```
 
 Set the logging level to one of the levels 'CRITICAL', 'ERROR', 'WARNING',
@@ -728,11 +1186,12 @@ Set the logging level to one of the levels 'CRITICAL', 'ERROR', 'WARNING',
 
 - `level` - a value like logging.INFO or a string like 'INFO'
 
-<a name="cmr.search.common.help_text"></a>
+<a id="cmr.search.common.help_text"></a>
+
 #### help\_text
 
 ```python
-help_text(prefix, functions, filters)
+def help_text(prefix, functions, filters)
 ```
 
 Built in help - prints out the public function names for the token API
@@ -741,7 +1200,8 @@ Built in help - prints out the public function names for the token API
 
 - `filter(string)` - filters out functions beginning with this text, defaults to all
 
-<a name="cmr.search.collection"></a>
+<a id="cmr.search.collection"></a>
+
 # cmr.search.collection
 
 A Library for building and requesting CMR collection searches
@@ -760,75 +1220,83 @@ This function can handle any query parameter which is supported by the CMR.
 More information can be found at:
 https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html
 
-<a name="cmr.search.collection.all_fields"></a>
+<a id="cmr.search.collection.all_fields"></a>
+
 #### all\_fields
 
 ```python
-all_fields(item)
+def all_fields(item)
 ```
 
 Makes no change to the item, passes through. Used primarily as an example
 and for testing the filter workflow
 
-<a name="cmr.search.collection.meta_fields"></a>
+<a id="cmr.search.collection.meta_fields"></a>
+
 #### meta\_fields
 
 ```python
-meta_fields(item)
+def meta_fields(item)
 ```
 
 Return only the the meta objects
 
-<a name="cmr.search.collection.umm_fields"></a>
+<a id="cmr.search.collection.umm_fields"></a>
+
 #### umm\_fields
 
 ```python
-umm_fields(item)
+def umm_fields(item)
 ```
 
 Return only the UMM part of the data
 
-<a name="cmr.search.collection.concept_id_fields"></a>
+<a id="cmr.search.collection.concept_id_fields"></a>
+
 #### concept\_id\_fields
 
 ```python
-concept_id_fields(item)
+def concept_id_fields(item)
 ```
 
 Extract only fields that are used to identify a record
 
-<a name="cmr.search.collection.drop_fields"></a>
+<a id="cmr.search.collection.drop_fields"></a>
+
 #### drop\_fields
 
 ```python
-drop_fields(key)
+def drop_fields(key)
 ```
 
 Drop a key from a dictionary
 
-<a name="cmr.search.collection.collection_core_fields"></a>
+<a id="cmr.search.collection.collection_core_fields"></a>
+
 #### collection\_core\_fields
 
 ```python
-collection_core_fields(item)
+def collection_core_fields(item)
 ```
 
 Extract only fields that are used to identify a record
 
-<a name="cmr.search.collection.collection_ids_for_granules_fields"></a>
+<a id="cmr.search.collection.collection_ids_for_granules_fields"></a>
+
 #### collection\_ids\_for\_granules\_fields
 
 ```python
-collection_ids_for_granules_fields(item: object)
+def collection_ids_for_granules_fields(item: object)
 ```
 
 Extract only the fields that are of interest to doing a granule search
 
-<a name="cmr.search.collection.apply_filters"></a>
+<a id="cmr.search.collection.apply_filters"></a>
+
 #### apply\_filters
 
 ```python
-apply_filters(filters, items)
+def apply_filters(filters, items)
 ```
 
 Apply all the filters on the downloaded data
@@ -842,20 +1310,22 @@ Apply all the filters on the downloaded data
 
   Filtered data
 
-<a name="cmr.search.collection.search"></a>
+<a id="cmr.search.collection.search"></a>
+
 #### search
 
 ```python
-search(query=None, filters=None, limit=None, config: dict = None)
+def search(query=None, filters=None, limit=None, config: dict = None)
 ```
 
 Search and return all records
 
-<a name="cmr.search.collection.set_logging_to"></a>
+<a id="cmr.search.collection.set_logging_to"></a>
+
 #### set\_logging\_to
 
 ```python
-set_logging_to(level)
+def set_logging_to(level)
 ```
 
 Set the logging level to the stated value. Any of the standard logging level
@@ -866,20 +1336,22 @@ can be used here. These include: DEBUG, INFO, WARNING, ERROR, and CRITICAL
 
 - `level` - a value like logging.INFO
 
-<a name="cmr.search.collection.open_api"></a>
+<a id="cmr.search.collection.open_api"></a>
+
 #### open\_api
 
 ```python
-open_api(section='#collection-search-by-parameters')
+def open_api(section='#collection-search-by-parameters')
 ```
 
 Ask python to open up the API in a new browser window
 
-<a name="cmr.search.collection.help_text"></a>
+<a id="cmr.search.collection.help_text"></a>
+
 #### help\_text
 
 ```python
-help_text(contains: str = "")
+def help_text(contains: str = "")
 ```
 
 Built in help - prints out the public function names for the collection object for the token API

--- a/CMR/python/doc/config_properties.md
+++ b/CMR/python/doc/config_properties.md
@@ -1,5 +1,11 @@
 # Document-it report
 All the code 'document-it' tags are listed here by package
+## `cmr`
+
+## `API Version`
+
+0.0.1
+
 ## `cmr.auth.token`
 
 ### `token_config()`
@@ -8,7 +14,6 @@ All the code 'document-it' tags are listed here by package
 
 ### `token_file()`
 
-* `cmr.token.file` (defaults to `~/.cmr_token`).
 
 ### `token_manager()`
 
@@ -25,12 +30,12 @@ All the code 'document-it' tags are listed here by package
       * also from `cmr.search.common._make_search_request`
         * `accept` (defaults to `application/vnd.nasa.cmr.umm_results+json`).
           * also from `cmr.search.common._standard_headers_from_config`
-            * `cmr-token` (defaults to `None`). Notes: also known as the echo token
+            * `Authorization` (defaults to `None`). Notes: also known as a cmr or EDL token
             * `X-Request-id` (defaults to `None`).
             * `Client-Id` (defaults to `python_cmr_lib`).
             * `User-Agent` (defaults to `python_cmr_lib`).
           * also from `cmr.search.common._cmr_query_url`
-              * also from `cmr.search.common._cmr_basic_url`
+              * also from `cmr.search.common.cmr_basic_url`
                 * `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
 
 ## `cmr.search.common`
@@ -38,24 +43,28 @@ All the code 'document-it' tags are listed here by package
 ### `clear_scroll()`
 
   * also from `cmr.search.common._standard_headers_from_config`
-    * `cmr-token` (defaults to `None`). Notes: also known as the echo token
+    * `Authorization` (defaults to `None`). Notes: also known as a cmr or EDL token
     * `X-Request-id` (defaults to `None`).
     * `Client-Id` (defaults to `python_cmr_lib`).
     * `User-Agent` (defaults to `python_cmr_lib`).
-  * also from `cmr.search.common._cmr_basic_url`
+  * also from `cmr.search.common.cmr_basic_url`
     * `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
+
+### `cmr_basic_url()`
+
+* `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
 
 ### `experimental_search_by_page_generator()`
 
   * also from `cmr.search.common._make_search_request`
     * `accept` (defaults to `application/vnd.nasa.cmr.umm_results+json`).
       * also from `cmr.search.common._standard_headers_from_config`
-        * `cmr-token` (defaults to `None`). Notes: also known as the echo token
+        * `Authorization` (defaults to `None`). Notes: also known as a cmr or EDL token
         * `X-Request-id` (defaults to `None`).
         * `Client-Id` (defaults to `python_cmr_lib`).
         * `User-Agent` (defaults to `python_cmr_lib`).
       * also from `cmr.search.common._cmr_query_url`
-          * also from `cmr.search.common._cmr_basic_url`
+          * also from `cmr.search.common.cmr_basic_url`
             * `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
 
 ### `search_by_page()`
@@ -64,12 +73,12 @@ All the code 'document-it' tags are listed here by package
   * also from `cmr.search.common._make_search_request`
     * `accept` (defaults to `application/vnd.nasa.cmr.umm_results+json`).
       * also from `cmr.search.common._standard_headers_from_config`
-        * `cmr-token` (defaults to `None`). Notes: also known as the echo token
+        * `Authorization` (defaults to `None`). Notes: also known as a cmr or EDL token
         * `X-Request-id` (defaults to `None`).
         * `Client-Id` (defaults to `python_cmr_lib`).
         * `User-Agent` (defaults to `python_cmr_lib`).
       * also from `cmr.search.common._cmr_query_url`
-          * also from `cmr.search.common._cmr_basic_url`
+          * also from `cmr.search.common.cmr_basic_url`
             * `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
 
 ## `cmr.search.granule`
@@ -80,12 +89,12 @@ All the code 'document-it' tags are listed here by package
       * also from `cmr.search.common._make_search_request`
         * `accept` (defaults to `application/vnd.nasa.cmr.umm_results+json`).
           * also from `cmr.search.common._standard_headers_from_config`
-            * `cmr-token` (defaults to `None`). Notes: also known as the echo token
+            * `Authorization` (defaults to `None`). Notes: also known as a cmr or EDL token
             * `X-Request-id` (defaults to `None`).
             * `Client-Id` (defaults to `python_cmr_lib`).
             * `User-Agent` (defaults to `python_cmr_lib`).
           * also from `cmr.search.common._cmr_query_url`
-              * also from `cmr.search.common._cmr_basic_url`
+              * also from `cmr.search.common.cmr_basic_url`
                 * `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
 
 ### `search()`
@@ -95,14 +104,14 @@ All the code 'document-it' tags are listed here by package
       * also from `cmr.search.common._make_search_request`
         * `accept` (defaults to `application/vnd.nasa.cmr.umm_results+json`).
           * also from `cmr.search.common._standard_headers_from_config`
-            * `cmr-token` (defaults to `None`). Notes: also known as the echo token
+            * `Authorization` (defaults to `None`). Notes: also known as a cmr or EDL token
             * `X-Request-id` (defaults to `None`).
             * `Client-Id` (defaults to `python_cmr_lib`).
             * `User-Agent` (defaults to `python_cmr_lib`).
           * also from `cmr.search.common._cmr_query_url`
-              * also from `cmr.search.common._cmr_basic_url`
+              * also from `cmr.search.common.cmr_basic_url`
                 * `env` (defaults to ``). Notes: uat, ops, prod, production, or blank for ops
 
 ----
-CMR Library - NASA - Copyright 2020-12-29
-Created 2020-12-29 09:08:43
+CMR Library - NASA - Copyright 2023-01-25
+Created 2023-01-25 15:34:07

--- a/CMR/python/docit.py
+++ b/CMR/python/docit.py
@@ -309,7 +309,8 @@ def tree(report, func_db, module, config=None, cache=None):
             '__path__',
             '__spec__',
             'Callable',
-            'logger']:
+            'logger',
+            'datetime']:
             out.append ("unknown: {} {}".format(obj_type, obj))
     if len(out) > 0:
         report.append ("\n".join(head))

--- a/CMR/python/runme.sh
+++ b/CMR/python/runme.sh
@@ -55,7 +55,7 @@ unit_test()
 {
     printf '*****************************************************************\n'
     printf 'Run the unit tests for all subdirectories\n'
-    pip3 install coverage
+    $pip3 install coverage
     coverage run --source=cmr -m unittest discover
     coverage html
 }

--- a/CMR/python/test/cmr/auth/test_token.py
+++ b/CMR/python/test/cmr/auth/test_token.py
@@ -130,8 +130,8 @@ class TestToken(unittest.TestCase):
     def test_use_bearer_token(self):
         """Test the function that handles all the work of tokens"""
         tokener = token.token_literal("test") #this always returns test as token
-        # pylint: disable=C0301 # lambdas must be on one line
-        tester = lambda expected, given, msg : self.assertEqual(expected, token.use_bearer_token(token_lambdas=tokener, config=given), msg)
+        def tester(expected, given, msg):
+            return self.assertEqual(expected, token.use_bearer_token(token_lambdas=tokener, config=given), msg)
 
         tester({"authorization":"Bearer test"}, None, "found from none")
         tester({"authorization":"Bearer test"}, {}, "found from nothing")
@@ -145,8 +145,8 @@ class TestToken(unittest.TestCase):
     # pylint: disable=W0212 ; test a private function
     def test__env_to_extention(self):
         """Check that the environment->extensions work as expected"""
-        # pylint: disable=C0301 # lambdas must be on one line
-        test = lambda expected, given, msg : self.assertEqual(expected, token._env_to_extention(given), msg)
+        def test(expected, given, msg):
+            return self.assertEqual(expected, token._env_to_extention(given), msg)
 
         test("", None, "No dictionary given")
         test("", {}, "Empty dictionary")
@@ -164,8 +164,8 @@ class TestToken(unittest.TestCase):
         """
         Test that an EDL URL can be generated with a given endpoint and config
         """
-        # pylint: disable=C0301 # lambdas must be on one line
-        test = lambda expected, given, config, msg : self.assertEqual(expected, token._env_to_edl_url(given, config=config), msg)
+        def test(expected, given, config, msg):
+            return self.assertEqual(expected, token._env_to_edl_url(given, config=config), msg)
 
         expected_token_ops = 'https://urs.earthdata.nasa.gov/api/users/token'
         expected_token_uat = 'https://uat.urs.earthdata.nasa.gov/api/users/token'
@@ -181,8 +181,8 @@ class TestToken(unittest.TestCase):
     # pylint: disable=W0212 ; test a private function
     def test_token_file_env(self):
         """Test the function that returns the token file path"""
-        # pylint: disable=C0301 # lambdas must be on one line
-        test = lambda expected, config, msg: self.assertEqual(expected, token._token_file_path(config), msg)
+        def test(expected, config, msg):
+            return self.assertEqual(expected, token._token_file_path(config), msg)
 
         test("~/.cmr_token", None, "Not specified")
         test("~/.cmr_token", {"env" : None}, "None value")
@@ -222,8 +222,8 @@ class TestToken(unittest.TestCase):
 
     def test__base64_text(self):
         "Test that the base64 library encodes values as the code expects"
-        # pylint: disable=C0301 # lambdas must be on one line
-        test = lambda expected, given, msg : self.assertEqual(expected, token._base64_text(given), msg)
+        def test(expected, given, msg):
+            return self.assertEqual(expected, token._base64_text(given), msg)
 
         test("", "", "Empty Test")
         test("RW5jb2RlIHRoaXMgbWVzc2FnZQ==", "Encode this message", "Value Test")
@@ -231,8 +231,9 @@ class TestToken(unittest.TestCase):
 
     def test__lambda_list_always(self):
         "Test the generation of a default lambda list "
-        # pylint: disable=C0301 # lambdas must be on one line
-        test = lambda expected, given, fallback, msg : self.assertEqual(expected, token._lamdba_list_always(given, fallback), msg)
+        def test(expected, given, fallback, msg):
+            self.assertEqual(expected, token._lamdba_list_always(given, fallback), msg)
+
         test([token.token_file, token.token_config], None, None, "None, with no fallback Test")
         test([], None, [], "None, with Empty fallback Test")
         test(['a'], 'a', None, "Not a list")
@@ -246,8 +247,9 @@ class TestToken(unittest.TestCase):
 
     def test__format_as_bearer_token(self):
         """ Make sure that the token can be wrapped as a bearer token correctly """
-        # pylint: disable=C0301 # lambdas must be on one line
-        test = lambda expected, given, msg : self.assertEqual(expected, token._format_as_bearer_token(given), msg)
+        def test(expected, given, msg):
+            return self.assertEqual(expected, token._format_as_bearer_token(given), msg)
+
         test("Bearer ", "", 'blank given')
         test("Bearer None", None, 'nothing given')
         test("Bearer token-here", 'token-here', 'token given')

--- a/CMR/python/test/cmr/search/test_common.py
+++ b/CMR/python/test/cmr/search/test_common.py
@@ -164,7 +164,7 @@ class TestSearch(unittest.TestCase):
             'X-Request-Id': '0123-45-6789',
             'Client-Id': 'fancy-client',
             'Not-A-Header': 'do not include me'}
-        defined_expected = {'Echo-Token': 'a-cmr-token',
+        defined_expected = {'Authorization': 'a-cmr-token',
             'X-Request-Id': '0123-45-6789',
             'User-Agent': 'python_cmr_lib',
             'Client-Id': 'fancy-client'}
@@ -173,7 +173,7 @@ class TestSearch(unittest.TestCase):
 
         config = {'cmr-token': 'a-cmr-token',
             'Not-A-Header': 'do not include me'}
-        token_expected = {'Echo-Token': 'a-cmr-token',
+        token_expected = {'Authorization': 'a-cmr-token',
             'User-Agent': 'python_cmr_lib',
             'Client-Id': 'python_cmr_lib'}
         token_result = scom._standard_headers_from_config(config)

--- a/CMR/python/test/cmr/search/test_common.py
+++ b/CMR/python/test/cmr/search/test_common.py
@@ -48,21 +48,27 @@ class TestSearch(unittest.TestCase):
 
     def test_meta_fields(self):
         """ Test that the meta fields are returned """
-        test = lambda exp, given, msg : self.assertEqual(exp, scom.meta_fields(given), msg)
+        def test(exp, given, msg):
+            return self.assertEqual(exp, scom.meta_fields(given), msg)
+
         test({}, {}, "empty")
         test({'key':'value'}, {'key':'value'}, "unrelated")
         test('meta-value', {'meta':'meta-value'}, "found a meta")
 
     def test_umm_fields(self):
         """ Test that the UMM fields are returned """
-        test = lambda exp, given, msg : self.assertEqual(exp, scom.umm_fields(given), msg)
+        def test(exp, given, msg):
+            return self.assertEqual(exp, scom.umm_fields(given), msg)
+
         test({}, {}, "empty")
         test({'key':'value'}, {'key':'value'}, "unrelated")
         test('umm-value', {'umm':'umm-value'}, "found a umm")
 
     def test_concept_id_fields(self):
         """ Test that the concept id fields are returned """
-        test = lambda exp, given, msg : self.assertEqual(exp, scom.concept_id_fields(given), msg)
+        def test(exp, given, msg):
+            return self.assertEqual(exp, scom.concept_id_fields(given), msg)
+
         test({}, {}, "empty")
         test({'key':'value'}, {'key':'value'}, "unrelated")
         test({'concept-id':'C123'}, {'meta':{'concept-id':'C123'}}, "found a concept-id in meta")
@@ -84,9 +90,12 @@ class TestSearch(unittest.TestCase):
 
     def test__error_object(self):
         """ Test that the Error Object is constructed correctly """
-        err = lambda code, msg : {'errors': [msg], 'code':code, 'reason':msg}
-        # pylint: disable=C0301 # lambda lines can not be shorter
-        test = lambda code, emsg, msg : self.assertEqual(err(code, emsg), scom._error_object(code, emsg), msg)
+        def err(code, msg):
+            return {'errors': [msg], 'code':code, 'reason':msg}
+
+        def test(code, emsg, msg):
+            return self.assertEqual(err(code, emsg), scom._error_object(code, emsg), msg)
+
         test(None, None, "nones")
         test(200, "OK", "200 msg")
         test(500, "Server Error", "500 error")
@@ -182,71 +191,81 @@ class TestSearch(unittest.TestCase):
     def test_cmr_basic_url(self):
         """ Test the inner function that supports test_cmr_query_url() """
 
-        # Lambda functions for testing in the most compact way posible. pylint
-        # will complain if lines are to long, lambda can only be on one line.
-        # Try to get the test lines to be as compact as are3 can be in CMR
+        # Inner functions for testing in the most compact way posible.
 
         # General Test of cmr_basic_url()
-        # Expected, Base, Query_params, Config, end_Point, Message
-        test_base = lambda e,b,q,c,p,m : self.assertEqual(e, scom.cmr_basic_url(b, q, c, p), m)
+        def test_base(exp, changes,msg):
+            base = changes[0]
+            query = changes[1]
+            config = changes[2]
+            epoint = changes[3]
+            return self.assertEqual(exp, scom.cmr_basic_url(base, query, config, epoint), msg)
 
         # Most common test assuming URL is HTTPS
-        # Expected, Base, Query_params, Config, Process, end Point, Message
-        test = lambda e,b,q,c,p,m : test_base(f'https://{e}', b, q, c, p, m)
+        def test(exp, changes, msg):
+            base = changes[0]
+            query = changes[1]
+            config = changes[2]
+            process = changes[3]
+            return test_base(f'https://{exp}', [base, query, config, process], msg)
 
         # Alt test assuming URL is HTTP
-        # Expected, Base, Query_params, Config, Process, end Point, Message
-        test_h = lambda e,b,q,c,p,m : test_base(f'http://{e}', b, q, c, p, m)
+        def test_h(exp, changes, msg):
+            base = changes[0]
+            query = changes[1]
+            config = changes[2]
+            process = changes[3]
+            return test_base(f'http://{exp}', [base, query, config, process], msg)
 
         # Short version of test() with many assumptions made
-        # Expected, Config-Env, Message
-        test2 = lambda e,c,m : test(f'{e}/search/','',{},{'env':c},None,m)
+        def test2(exp, config, msg):
+            return test(f'{exp}/search/', ['', {}, {'env':config}, None], msg)
 
         # Expected, Base, Query_params, Config, Process, end Point, Message
-        test('cmr.earthdata.nasa.gov/search/', None, None, None, None, 'Nothing provided')
-        test('cmr.earthdata.nasa.gov/search/', '', {}, {}, None, 'all empty')
-        test('cmr.earthdata.nasa.gov/search/param', 'param', {}, {}, None, 'only path param')
+        test('cmr.earthdata.nasa.gov/search/', [None, None, None, None], 'Nothing provided')
+        test('cmr.earthdata.nasa.gov/search/', ['', {}, {}, None], 'all empty')
+        test('cmr.earthdata.nasa.gov/search/param', ['param', {}, {}, None], 'only path param')
         test('cmr.earthdata.nasa.gov/search/?pretty=true',
-            '',
+            ['',
             {'pretty':'true'},
             {},
-            None,
+            None],
             'only query param')
         test('cmr.earthdata.nasa.gov/search/param?pretty=true',
-            'param',
+            ['param',
             {'pretty':'true'},
             {},
-            None,
+            None],
             'all empty')
         test('cmr.earthdata.nasa.gov/search/',
-            '',
+            ['',
             {},
             {'pretty':'true'},
-            None,
+            None],
             'param used as env')
         test('cmr.earthdata.nasa.gov/search/collections/tar..estuary/?keyword=tar..estuary',
-            'collections/tar..estuary/',
+            ['collections/tar..estuary/',
             {'keyword':'tar..estuary'},
             {'env': 'ops'},
-            None,
+            None],
             'only remove the first double dot, science data shoud be allowed to use dot dot')
         test_h('localhost:3003/keywords/platforms?pretty=true',
-            'keywords/platforms',
+            ['keywords/platforms',
             {'pretty':'true'},
             {'env':'localhost'},
-            None,
+            None],
             "localhost url to the KMS Keywords interface")
         test_h('localhost:3003/keywords/platforms?pretty=true',
-            'keywords/platforms',
+            ['keywords/platforms',
             {'pretty':'true'},
             {'env':'localhost'},
-            None,
+            None],
             "localhost url to the KMS Keywords interface")
         test_h('localhost:3002/providers?pretty=true',
-            'providers',
+            ['providers',
             {'pretty':'true'},
             {'env':'localhost'},
-            'ingest',
+            'ingest'],
             "localhost url to the provider report from ingest interface")
 
         # Expected, Config-Env, Message

--- a/CMR/python/test/cmr/search/test_granule.py
+++ b/CMR/python/test/cmr/search/test_granule.py
@@ -330,8 +330,8 @@ class TestSearch(unittest.TestCase):
         # cut down the function parameters to assume all the parts that will not change
         runner = partial(gran.sample_by_collections, collection_query, filters=filters)
 
-        # pylint: disable=C0301 # lambda must be on one line
-        tester = lambda expected, limit, msg : self.assertEqual(expected, runner(limits=limit), msg)
+        def tester(expected, limit, msg):
+            return self.assertEqual(expected, runner(limits=limit), msg)
 
         expected = [{'concept-id': 'G1527288030-SEDAC'},
             {'concept-id': 'G1527288030-SEDAC'},

--- a/CMR/python/test/cmr/search/test_search.py
+++ b/CMR/python/test/cmr/search/test_search.py
@@ -218,7 +218,6 @@ class TestSearch(unittest.TestCase):
         self.assertEqual (expected, result)
 
     # Ignore this so that an example of how to run the code can be documented
-    # pylint: disable=R0201
     def _test_live_search(self):
         """
         Make a live call to CMR, this is not normally included in the test suite.

--- a/CMR/python/test/cmr/search/test_search.py
+++ b/CMR/python/test/cmr/search/test_search.py
@@ -266,8 +266,7 @@ class TestSearch(unittest.TestCase):
         # Test
         with self.assertLogs(coll.scom.logger, level='DEBUG') as log_collector:
             coll.set_logging_to("DEBUG")
-            expected = ['INFO:cmr.search.common:Using a CMR-Token',
-                        'INFO:cmr.search.common:Using an Authorization token',
+            expected = ['INFO:cmr.search.common:Using an Authorization token',
                         'INFO:cmr.search.common: - POST: https://cmr.earthdata.'
                             'nasa.gov/search/collections?page_size=1',
                         'INFO:cmr.search.common:Total records downloaded was 10'

--- a/CMR/python/test/cmr/util/test_common.py
+++ b/CMR/python/test/cmr/util/test_common.py
@@ -72,8 +72,9 @@ class TestSearch(unittest.TestCase):
 
     def test_drop_key_safely(self):
         """Test that values can be dropped safely"""
-        # pylint: disable=C0301 # lambdas must be on one line
-        tester = lambda expected, src, key, msg : self.assertEqual(expected, com.drop_key_safely(src, key), msg)
+        def tester (expected, src, key, msg):
+            return self.assertEqual(expected, com.drop_key_safely(src, key), msg)
+
         tester({}, {}, "Not existing", "Empty dictionary")
         tester({"key":"value"}, {"key": "value"}, "not found", "wrong key, no drop")
         tester({}, {"key":"value"}, "key", "drop found key")
@@ -92,8 +93,9 @@ class TestSearch(unittest.TestCase):
 
     def test_execute_command(self):
         """Execute will run any command, test that it behaves as expected"""
-        # pylint: disable=C0301 # lambdas must be on one line
-        tester = lambda expected, given, msg : self.assertEqual(expected, com.execute_command(given), msg)
+        def tester (expected, given, msg):
+            return self.assertEqual(expected, com.execute_command(given), msg)
+
         tester("", "true", "Test a single command response")
         tester("_result_", ["printf", '_%s_', 'result'], "Test a command with properties")
 
@@ -118,8 +120,8 @@ class TestSearch(unittest.TestCase):
 
     def test_mask_string(self):
         """Test that the mask_diictionary function will clean out sensitive info"""
-        # pylint: disable=C0301 # lambdas must be on one line
-        tester = lambda expected, given, msg : self.assertEqual(expected, com.mask_string(given), msg)
+        def tester(expected, given, msg):
+            return self.assertEqual(expected, com.mask_string(given), msg)
 
         tester("", None, "None sent")
         tester("", "", "No Letters")

--- a/CMR/python/test/cmr/util/test_network.py
+++ b/CMR/python/test/cmr/util/test_network.py
@@ -56,7 +56,9 @@ class TestSearch(unittest.TestCase):
     def test_value_to_param(self):
         """ Test that a value can be converted to a URL parameter """
         # pylint: disable=C0301 # lambda lines can be shorter
-        test = lambda expected, key, value, msg : self.assertEqual(expected, net.value_to_param(key, value), msg)
+        def test(expected, key, value, msg):
+            return self.assertEqual(expected, net.value_to_param(key, value), msg)
+
         test("key=value", "key", "value", "Basic")
         test("key=", "key", "", "Missing Value")
         test("=value", "", "value", "Missing Key")
@@ -136,8 +138,9 @@ class TestSearch(unittest.TestCase):
         Test the helper function which converts values in the config dictionary
         to the header dictionary
         """
-        # pylint: disable=C0301 # lambda lines can be shorter
-        test = lambda exp, opt, src, head, dest=None, defa=None : self.assertEqual(exp, net.config_to_header(opt, src, head, dest, defa))
+        # pylint: disable=R0913 # not to many parameters
+        def test(exp, opt, src, head, dest=None, defa=None):
+            return self.assertEqual(exp, net.config_to_header(opt, src, head, dest, defa))
 
         test(None, None, None, None)
         test({}, {}, 'user-setting', {})


### PR DESCRIPTION
CMR-8895 requests that all references to ECHO Tokens as this feature is being deprecated across all of CMR and CMR related applications.

Dropping functionality in favor of an Authorization header (which was already supported).

A new script exists to demo and test this change, run demos/scripts/edl_token.py.

Additionally an existing test script was added at demos/scripts/providers.py to demo that feature added some time ago.